### PR TITLE
Fix README typo in Contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ See [the roadmap](https://my.vikunja.cloud/share/QFyzYEmEYfSyQfTOmIRSwLUpkFjboaB
 
 ## Contributing
 
-Please check out the contribuition guidelines on [the website](https://vikunja.io/docs/development/).
+Please check out the contribution guidelines on [the website](https://vikunja.io/docs/development/).
 
 ## License
 


### PR DESCRIPTION
## Summary
- fix `contribuition` typo in README

## Testing
- `go test ./...` *(fails: unable to download go toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_6840008e34908320b88d33da96444cdd