### PR TITLE
Update TipTap editor

### DIFF
--- a/frontend/src/components/input/editor/TipTap.vue
+++ b/frontend/src/components/input/editor/TipTap.vue
@@ -137,7 +137,7 @@
 </template>
 
 <script setup lang="ts">
-import {computed, nextTick, onBeforeUnmount, onMounted, ref, watch} from 'vue'
+import {computed, nextTick, onBeforeUnmount, onMounted, ref, watch, watchEffect} from 'vue'
 import {useI18n} from 'vue-i18n'
 import {eventToHotkeyString} from '@github/hotkey'
 
@@ -184,7 +184,6 @@ import inputPrompt from '@/helpers/inputPrompt'
 import {setLinkInEditor} from '@/components/input/editor/setLinkInEditor'
 
 const props = withDefaults(defineProps<{
-	modelValue: string,
 	uploadCallback?: UploadCallback,
 	isEditEnabled?: boolean,
 	bottomActions?: BottomAction[],
@@ -202,7 +201,8 @@ const props = withDefaults(defineProps<{
 	enableDiscardShortcut: false,
 })
 
-const emit = defineEmits(['update:modelValue', 'save'])
+const modelValue = defineModel<string>({ default: '' })
+const emit = defineEmits(['save'])
 
 const tiptapInstanceRef = ref<HTMLInputElement | null>(null)
 
@@ -267,7 +267,7 @@ const CustomImage = Image.extend({
 
 			nextTick(async () => {
 
-				const img = document.getElementById(id)
+				const img = document.getElementById(id) as HTMLImageElement | null
 
 				if (!img) return
 
@@ -308,7 +308,7 @@ const UPLOAD_PLACEHOLDER_ELEMENT = '<p>UPLOAD_PLACEHOLDER</p>'
 let lastSavedState = ''
 
 watch(
-	() => props.modelValue,
+	modelValue,
 	(newValue) => {
 		if (!contentHasChanged.value) {
 			lastSavedState = newValue
@@ -347,8 +347,7 @@ const PasteHandler = Extension.create({
 						if (typeof props.uploadCallback !== 'undefined' && event.clipboardData?.items?.length > 0) {
 
 							for (const item of event.clipboardData.items) {
-								console.log({item})
-								if (item.kind === 'file' && item.type.startsWith('image/')) {
+				if (item.kind === 'file' && item.type.startsWith('image/')) {
 									const file = item.getAsFile()
 									if (file) {
 										uploadAndInsertFiles([file])
@@ -496,16 +495,10 @@ const editor = useEditor({
 	},
 })
 
-watch(
-	() => isEditing.value,
-	() => {
-		editor.value?.setEditable(isEditing.value)
-	},
-	{immediate: true},
-)
+watchEffect(() => editor.value?.setEditable(isEditing.value))
 
 watch(
-	() => props.modelValue,
+	modelValue,
 	value => {
 		if (!editor?.value) return
 
@@ -519,13 +512,13 @@ watch(
 )
 
 function bubbleNow() {
-	if (editor.value?.getHTML() === props.modelValue ||
-		(editor.value?.getHTML() === '<p></p>') && props.modelValue === '') {
+	if (editor.value?.getHTML() === modelValue.value ||
+		(editor.value?.getHTML() === '<p></p>') && modelValue.value === '') {
 		return
 	}
 
 	contentHasChanged.value = true
-	emit('update:modelValue', editor.value?.getHTML())
+	modelValue.value = editor.value?.getHTML() ?? ''
 }
 
 function bubbleSave() {
@@ -633,7 +626,7 @@ onMounted(async () => {
 
 	await nextTick()
 
-	setModeAndValue(props.modelValue)
+	setModeAndValue(modelValue.value)
 })
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
## Summary
- clean up `pasteHandler` debug output
- use `defineModel` for the editor's v-model value
- set editor editability with `watchEffect`
- fix image type and update reactive model usage
- restore tab indentation for the new code

## Testing
- `pnpm run lint` *(fails: Cannot find package 'eslint-plugin-vue')*
- `pnpm run test:unit` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401e42ded08320b76ab48fea489079