### PR TITLE
Replace tippy.js with floating-ui

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -96,7 +96,7 @@
     "register-service-worker": "1.7.2",
     "sortablejs": "1.15.6",
     "tailwindcss": "3.4.17",
-    "tippy.js": "6.3.7",
+    "@floating-ui/dom": "1.7.1",
     "ufo": "1.6.1",
     "vue": "3.5.16",
     "vue-advanced-cropper": "2.8.9",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
 
   .:
     dependencies:
+      '@floating-ui/dom':
+        specifier: 1.7.1
+        version: 1.7.1
       '@fortawesome/fontawesome-svg-core':
         specifier: 6.7.2
         version: 6.7.2
@@ -163,9 +166,6 @@ importers:
       tailwindcss:
         specifier: 3.4.17
         version: 3.4.17
-      tippy.js:
-        specifier: 6.3.7
-        version: 6.3.7
       ufo:
         specifier: 1.6.1
         version: 1.6.1
@@ -1568,11 +1568,20 @@ packages:
   '@floating-ui/core@1.6.7':
     resolution: {integrity: sha512-yDzVT/Lm101nQ5TCVeK65LtdN7Tj4Qpr9RTXJ2vPFLqtLxwOrpoxAHAJI8J3yYWUc40J0BDBheaitK5SJmno2g==}
 
+  '@floating-ui/core@1.7.1':
+    resolution: {integrity: sha512-azI0DrjMMfIug/ExbBaeDVJXcY0a7EPvPjb2xAJPa4HeimBX+Z18HK8QQR3jb6356SnDDdxx+hinMLcJEDdOjw==}
+
   '@floating-ui/dom@1.1.1':
     resolution: {integrity: sha512-TpIO93+DIujg3g7SykEAGZMDtbJRrmnYRCNYSjJlvIbGhBjRSNTLVbNeDQBrzy9qDgUbiWdc7KA0uZHZ2tJmiw==}
 
+  '@floating-ui/dom@1.7.1':
+    resolution: {integrity: sha512-cwsmW/zyw5ltYTUeeYJ60CnQuPqmGwuGVhG9w0PRaRKkAyi38BT5CKrpIbb+jtahSwUl04cWzSx9ZOIxeS6RsQ==}
+
   '@floating-ui/utils@0.2.7':
     resolution: {integrity: sha512-X8R8Oj771YRl/w+c1HqAC1szL8zWQRwFvgDwT129k9ACdBoud/+/rX9V0qiMl6LWUdP9voC2nDVZYPMQQsb6eA==}
+
+  '@floating-ui/utils@0.2.9':
+    resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
 
   '@fortawesome/fontawesome-common-types@6.7.2':
     resolution: {integrity: sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==}
@@ -8241,11 +8250,22 @@ snapshots:
     dependencies:
       '@floating-ui/utils': 0.2.7
 
+  '@floating-ui/core@1.7.1':
+    dependencies:
+      '@floating-ui/utils': 0.2.9
+
   '@floating-ui/dom@1.1.1':
     dependencies:
       '@floating-ui/core': 1.6.7
 
+  '@floating-ui/dom@1.7.1':
+    dependencies:
+      '@floating-ui/core': 1.7.1
+      '@floating-ui/utils': 0.2.9
+
   '@floating-ui/utils@0.2.7': {}
+
+  '@floating-ui/utils@0.2.9': {}
 
   '@fortawesome/fontawesome-common-types@6.7.2': {}
 

--- a/frontend/src/components/input/editor/suggestion.ts
+++ b/frontend/src/components/input/editor/suggestion.ts
@@ -1,5 +1,5 @@
 import {VueRenderer} from '@tiptap/vue-3'
-import tippy from 'tippy.js'
+import {createFloatingPopup} from '@/helpers/floatingPopup'
 
 import CommandsList from './CommandsList.vue'
 
@@ -171,15 +171,13 @@ export default function suggestionSetup(t) {
                         return
                     }
 
-                    popup = tippy('body', {
+                    popup = createFloatingPopup({
                         getReferenceClientRect: props.clientRect,
                         appendTo: () => document.body,
                         content: component.element,
-                        showOnCreate: true,
-                        interactive: true,
-                        trigger: 'manual',
                         placement: 'bottom-start',
                     })
+                    popup.show()
                 },
 
                 onUpdate(props) {
@@ -189,14 +187,14 @@ export default function suggestionSetup(t) {
                         return
                     }
 
-                    popup[0].setProps({
+                    popup.setProps({
                         getReferenceClientRect: props.clientRect,
                     })
                 },
 
                 onKeyDown(props) {
                     if (props.event.key === 'Escape') {
-                        popup[0].hide()
+                        popup.hide()
 
                         return true
                     }
@@ -205,7 +203,7 @@ export default function suggestionSetup(t) {
                 },
 
                 onExit() {
-                    popup[0].destroy()
+                    popup.destroy()
                     component.destroy()
                 },
             }

--- a/frontend/src/helpers/floatingPopup.ts
+++ b/frontend/src/helpers/floatingPopup.ts
@@ -1,0 +1,66 @@
+import {computePosition, autoUpdate, flip, shift, offset, Placement, VirtualElement} from '@floating-ui/dom'
+
+interface Options {
+    getReferenceClientRect: () => DOMRect
+    content: HTMLElement | string
+    placement?: Placement
+    appendTo?: () => HTMLElement
+}
+
+export function createFloatingPopup(options: Options) {
+    const {
+        getReferenceClientRect,
+        content,
+        placement = 'bottom-start',
+        appendTo = () => document.body,
+    } = options
+
+    const reference: VirtualElement = {
+        getBoundingClientRect: getReferenceClientRect,
+    }
+
+    const el: HTMLElement = typeof content === 'string'
+        ? (() => {
+            const wrapper = document.createElement('div')
+            wrapper.innerHTML = content
+            return wrapper.firstElementChild as HTMLElement || wrapper
+        })()
+        : content
+
+    el.style.position = 'absolute'
+    appendTo().appendChild(el)
+
+    const update = () => {
+        computePosition(reference, el, {
+            placement,
+            middleware: [offset(0), flip(), shift()],
+        }).then(({x, y}) => {
+            Object.assign(el.style, {
+                left: `${x}px`,
+                top: `${y}px`,
+            })
+        })
+    }
+
+    const cleanup = autoUpdate(reference, el, update)
+    update()
+
+    return {
+        element: el,
+        show() {
+            el.style.display = ''
+            update()
+        },
+        hide() {
+            el.style.display = 'none'
+        },
+        destroy() {
+            cleanup()
+            el.remove()
+        },
+        setProps({getReferenceClientRect: fn}: {getReferenceClientRect: () => DOMRect}) {
+            reference.getBoundingClientRect = fn
+            update()
+        },
+    }
+}

--- a/frontend/src/helpers/inputPrompt.ts
+++ b/frontend/src/helpers/inputPrompt.ts
@@ -1,5 +1,5 @@
 import {createRandomID} from '@/helpers/randomId'
-import tippy from 'tippy.js'
+import {createFloatingPopup} from '@/helpers/floatingPopup'
 import {nextTick} from 'vue'
 import {eventToHotkeyString} from '@github/hotkey'
 
@@ -7,18 +7,14 @@ export default function inputPrompt(pos: ClientRect, oldValue: string = ''): Pro
 	return new Promise((resolve) => {
 		const id = 'link-input-' + createRandomID()
 
-		const linkPopup = tippy('body', {
-			getReferenceClientRect: () => pos,
-			appendTo: () => document.body,
-			content: `<div><input class="input" placeholder="URL" id="${id}" value="${oldValue}"/></div>`,
-			showOnCreate: true,
-			interactive: true,
-			trigger: 'manual',
-			placement: 'top-start',
-			allowHTML: true,
-		})
+               const linkPopup = createFloatingPopup({
+                       getReferenceClientRect: () => pos,
+                       appendTo: () => document.body,
+                       content: `<div><input class="input" placeholder="URL" id="${id}" value="${oldValue}"/></div>`,
+                       placement: 'top-start',
+               })
 
-		linkPopup[0].show()
+               linkPopup.show()
 
 		nextTick(() => document.getElementById(id)?.focus())
 
@@ -32,7 +28,7 @@ export default function inputPrompt(pos: ClientRect, oldValue: string = ''): Pro
 
 			resolve(url)
 
-			linkPopup[0].hide()
+                       linkPopup.hide()
 		})
 
 	})


### PR DESCRIPTION
## Summary
- swap tippy.js for floating-ui
- add helper to create floating popups
- use floating popups for editor suggestion and link prompt
- update dependency list

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Cannot find name 'ImportMetaEnv' and other errors)*
- `pnpm exec vitest run`
- `mage test:unit` *(fails: command not found)*
- `mage test:integration` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402caf61888320ba60db54304930e9