### PR TITLE
Fix email confirm test

### DIFF
--- a/pkg/user/user_email_confirm_test.go
+++ b/pkg/user/user_email_confirm_test.go
@@ -67,8 +67,18 @@ func TestUserEmailConfirm(t *testing.T) {
 			s := db.NewSession()
 			defer s.Close()
 
-			if err := ConfirmEmail(s, tt.args.c); (err != nil) != tt.wantErr {
+			err := ConfirmEmail(s, tt.args.c)
+			if (err != nil) != tt.wantErr {
 				t.Errorf("ConfirmEmail() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				if tt.errType != nil {
+					if !tt.errType(err) {
+						t.Errorf("ConfirmEmail() wrong error type: %v", err)
+					}
+				} else {
+					t.Errorf("ConfirmEmail() returned unexpected error: %v", err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- enforce error type check in `TestUserEmailConfirm`

## Testing
- `go mod download`
- `go test ./pkg/user` *(fails: unable to complete in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6840017cec148320b59046b9765655ce