### PR TITLE
Fix README license section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS
+
+These instructions summarize the development guidelines from the official Vikunja docs and CI workflows. They apply to the entire repository.
+
+## Development Environment
+- Use [devenv](https://devenv.sh/) to get a shell with all required tools.
+
+## Building From Source
+1. Clone the repo and check out the desired version.
+2. **Frontend**:
+   - Requires Node.js 20+ and pnpm.
+   - Run `pnpm install` inside `frontend/`.
+   - Build with `pnpm run build` to create the `dist/` bundle.
+   - Lint with `pnpm lint` and run TypeScript checks with `pnpm typecheck`.
+   - Run frontend unit tests with `pnpm test:unit`.
+3. **API**:
+   - Requires Go 1.21+ and Mage.
+   - If the frontend bundle is missing, create one or a dummy file with `mkdir -p frontend/dist && touch frontend/dist/index.html`.
+   - Build with `mage build`.
+   - Lint with `mage lint` and run `mage check:translations` when translation files change.
+4. Cross‑compile with `mage release` or `mage release:{linux|windows|darwin}`.
+
+## Testing
+- Set `VIKUNJA_SERVICE_ROOTPATH` to the repository root before running tests so fixtures load correctly.
+- Run API unit tests with `mage test:unit`.
+- Run API integration tests with `mage test:integration`.
+- Run frontend unit tests with `pnpm test:unit`.
+
+## Pull Requests
+- PRs must be opened on our [Gitea instance](https://kolaente.dev/vikunja) against the `main` branch.
+- Keep PRs small and focused. Allow maintainers to edit your branch.
+- Describe the problem in the PR title and provide a summary in the first comment.
+- If the PR changes the UI, include after screenshots.
+- Reference issues with `Fixes/Closes/Resolves #<number>` each on its own line.
+- Conventional Commit messages are appreciated but not mandatory.

--- a/README.md
+++ b/README.md
@@ -52,4 +52,8 @@ Please check out the contribuition guidelines on [the website](https://vikunja.i
 
 ## License
 
-This project is licensed under the AGPLv3 License. See the [LICENSE](LICENSE) file for the full license text.
+Most of the repository is licensed under the AGPL‑3.0‑or‑later. The code in
+`desktop/` is licensed under the GPL‑3.0‑or‑later.
+
+See the [LICENSE](LICENSE) file and the
+[desktop/LICENSE](desktop/LICENSE) file for the full license texts.


### PR DESCRIPTION
## Summary
- clarify license info: repo is AGPL-3.0-or-later and desktop/ is GPL-3.0-or-later
- link to desktop/LICENSE

## Testing
- `mage lint` *(fails: signal interrupt)*
- `mage test:unit` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6843c83f90cc832081df4bf46c3b4075