### PR TITLE
Update package.json automatically on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,3 +296,54 @@ jobs:
         with:
           ssh: true
           branch: ${{ github.ref }}
+
+  update-frontend-version:
+    if: ${{ github.ref_type == 'tag' }}
+    runs-on: ubuntu-latest
+    needs:
+      - generate-swagger-docs
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          persist-credentials: true
+      - name: Git describe
+        id: ghd
+        uses: proudust/gh-describe@v2
+      - name: Download Mage Binary
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: mage_bin
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
+        with:
+          go-version: stable
+      - name: Update version files
+        env:
+          RELEASE_VERSION: ${{ steps.ghd.outputs.describe }}
+        run: |
+          chmod +x ./mage-static
+          ./mage-static generate:frontend-version
+      - name: Check for changes
+        id: check_version
+        run: |
+          if git diff --quiet; then
+            echo "changes_exist=0" >> "$GITHUB_OUTPUT"
+          else
+            echo "changes_exist=1" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Commit version bump
+        if: steps.check_version.outputs.changes_exist != '0'
+        run: |
+          git config --local user.email "bot@vikunja.io"
+          git config --local user.name "Frederick [Bot]"
+          git commit -am "[skip ci] Update frontend version"
+      - name: Push changes
+        if: steps.check_version.outputs.changes_exist != '0'
+        uses: ad-m/github-push-action@master
+        with:
+          ssh: true
+          branch: ${{ github.ref }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS
+
+These instructions summarize the development guidelines from the official Vikunja docs and CI workflows. They apply to the entire repository.
+
+## Development Environment
+- Use [devenv](https://devenv.sh/) to get a shell with all required tools.
+
+## Building From Source
+1. Clone the repo and check out the desired version.
+2. **Frontend**:
+   - Requires Node.js 20+ and pnpm.
+   - Run `pnpm install` inside `frontend/`.
+   - Build with `pnpm run build` to create the `dist/` bundle.
+   - Lint with `pnpm lint` and run TypeScript checks with `pnpm typecheck`.
+   - Run frontend unit tests with `pnpm test:unit`.
+3. **API**:
+   - Requires Go 1.21+ and Mage.
+   - If the frontend bundle is missing, create one or a dummy file with `mkdir -p frontend/dist && touch frontend/dist/index.html`.
+   - Build with `mage build`.
+   - Lint with `mage lint` and run `mage check:translations` when translation files change.
+4. Cross‑compile with `mage release` or `mage release:{linux|windows|darwin}`.
+
+## Testing
+- Set `VIKUNJA_SERVICE_ROOTPATH` to the repository root before running tests so fixtures load correctly.
+- Run API unit tests with `mage test:unit`.
+- Run API integration tests with `mage test:integration`.
+- Run frontend unit tests with `pnpm test:unit`.
+
+## Pull Requests
+- PRs must be opened on our [Gitea instance](https://kolaente.dev/vikunja) against the `main` branch.
+- Keep PRs small and focused. Allow maintainers to edit your branch.
+- Describe the problem in the PR title and provide a summary in the first comment.
+- If the PR changes the UI, include after screenshots.
+- Reference issues with `Fixes/Closes/Resolves #<number>` each on its own line.
+- Conventional Commit messages are appreciated but not mandatory.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "vikunja-frontend",
   "description": "The todo app to organize your life.",
   "private": true,
-  "version": "0.10.0",
+  "version": "0.24.6",
   "license": "AGPL-3.0-or-later",
   "repository": {
     "type": "git",

--- a/frontend/src/version.json
+++ b/frontend/src/version.json
@@ -1,3 +1,3 @@
 {
-  "VERSION": "dev"
+  "VERSION": "0.24.6"
 }


### PR DESCRIPTION
## Summary
- add a mage target to sync frontend version files
- invoke this target from the release workflow and push changes
- keep initVars from modifying files during normal builds

## Testing
- `mage lint`
- `mage test:unit`
- `pnpm install`
- `pnpm test:unit` *(tests passed but process cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68403a82563c832095a9635f7eca1d5f