### PR TITLE
Add usage notice for migration logos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS
+
+These instructions summarize the development guidelines from the official Vikunja docs and CI workflows. They apply to the entire repository.
+
+## Development Environment
+- Use [devenv](https://devenv.sh/) to get a shell with all required tools.
+
+## Building From Source
+1. Clone the repo and check out the desired version.
+2. **Frontend**:
+   - Requires Node.js 20+ and pnpm.
+   - Run `pnpm install` inside `frontend/`.
+   - Build with `pnpm run build` to create the `dist/` bundle.
+   - Lint with `pnpm lint` and run TypeScript checks with `pnpm typecheck`.
+   - Run frontend unit tests with `pnpm test:unit`.
+3. **API**:
+   - Requires Go 1.21+ and Mage.
+   - If the frontend bundle is missing, create one or a dummy file with `mkdir -p frontend/dist && touch frontend/dist/index.html`.
+   - Build with `mage build`.
+   - Lint with `mage lint` and run `mage check:translations` when translation files change.
+4. Cross‑compile with `mage release` or `mage release:{linux|windows|darwin}`.
+
+## Testing
+- Set `VIKUNJA_SERVICE_ROOTPATH` to the repository root before running tests so fixtures load correctly.
+- Run API unit tests with `mage test:unit`.
+- Run API integration tests with `mage test:integration`.
+- Run frontend unit tests with `pnpm test:unit`.
+
+## Pull Requests
+- PRs must be opened on our [Gitea instance](https://kolaente.dev/vikunja) against the `main` branch.
+- Keep PRs small and focused. Allow maintainers to edit your branch.
+- Describe the problem in the PR title and provide a summary in the first comment.
+- If the PR changes the UI, include after screenshots.
+- Reference issues with `Fixes/Closes/Resolves #<number>` each on its own line.
+- Conventional Commit messages are appreciated but not mandatory.

--- a/frontend/originalMedia/images/migration/README.md
+++ b/frontend/originalMedia/images/migration/README.md
@@ -1,0 +1,10 @@
+# Migration Logos
+
+The images in this directory are used by Vikunja's import feature to represent third-party services. Each logo is owned by its respective trademark holder:
+
+* **microsoft-todo.svg** – Microsoft To Do logo. See Microsoft's [Trademark and Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks) for permitted uses.
+* **todoist.svg** – Todoist logo. Trademark of Doist Ltd. Use must follow Doist's [brand guidelines](https://todoist.com/brand) or press kit.
+* **trello.svg** – Trello logo. Trademark of Atlassian Pty Ltd. Use must comply with Atlassian's [Trademark Guidelines](https://www.atlassian.com/legal/trademark).
+* **wunderlist.png** – Wunderlist logo. Trademark of Microsoft Corporation. Covered by Microsoft's [Trademark and Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks).
+
+These logos are provided only to show that Vikunja can import tasks from these services. Their inclusion does not imply endorsement by the trademark owners. Do not use the logos except as allowed by the respective brand policies.


### PR DESCRIPTION
## Summary
- note that the logos used for migrations are trademarks of their owners

## Testing
- `pnpm lint` *(fails: cannot find package 'eslint-plugin-vue')*
- `pnpm typecheck` *(fails: vue-tsc not found)*
- `pnpm test:unit` *(fails: vitest not found)*
- `mage lint` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6843ce12415c8320a395f9a5f6a02dab