### PR TITLE
docs: clarify license badges

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS
+
+These instructions summarize the development guidelines from the official Vikunja docs and CI workflows. They apply to the entire repository.
+
+## Development Environment
+- Use [devenv](https://devenv.sh/) to get a shell with all required tools.
+
+## Building From Source
+1. Clone the repo and check out the desired version.
+2. **Frontend**:
+   - Requires Node.js 20+ and pnpm.
+   - Run `pnpm install` inside `frontend/`.
+   - Build with `pnpm run build` to create the `dist/` bundle.
+   - Lint with `pnpm lint` and run TypeScript checks with `pnpm typecheck`.
+   - Run frontend unit tests with `pnpm test:unit`.
+3. **API**:
+   - Requires Go 1.21+ and Mage.
+   - If the frontend bundle is missing, create one or a dummy file with `mkdir -p frontend/dist && touch frontend/dist/index.html`.
+   - Build with `mage build`.
+   - Lint with `mage lint` and run `mage check:translations` when translation files change.
+4. Cross‑compile with `mage release` or `mage release:{linux|windows|darwin}`.
+
+## Testing
+- Set `VIKUNJA_SERVICE_ROOTPATH` to the repository root before running tests so fixtures load correctly.
+- Run API unit tests with `mage test:unit`.
+- Run API integration tests with `mage test:integration`.
+- Run frontend unit tests with `pnpm test:unit`.
+
+## Pull Requests
+- PRs must be opened on our [Gitea instance](https://kolaente.dev/vikunja) against the `main` branch.
+- Keep PRs small and focused. Allow maintainers to edit your branch.
+- Describe the problem in the PR title and provide a summary in the first comment.
+- If the PR changes the UI, include after screenshots.
+- Reference issues with `Fixes/Closes/Resolves #<number>` each on its own line.
+- Conventional Commit messages are appreciated but not mandatory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,27 +4,33 @@ These instructions summarize the development guidelines from the official Vikunj
 
 ## Development Environment
 - Use [devenv](https://devenv.sh/) to get a shell with all required tools.
+- Respect the formatting rules from `.editorconfig` in the repository root and
+        all subfolders.
+- The CI uses the Node.js version defined in `frontend/.nvmrc` (currently 22)
+        and Go 1.23 from `go.mod`.
 
 ## Building From Source
 1. Clone the repo and check out the desired version.
+
 2. **Frontend**:
-   - Requires Node.js 20+ and pnpm.
-   - Run `pnpm install` inside `frontend/`.
-   - Build with `pnpm run build` to create the `dist/` bundle.
-   - Lint with `pnpm lint` and run TypeScript checks with `pnpm typecheck`.
-   - Run frontend unit tests with `pnpm test:unit`.
+	- Requires Node.js 22+ and pnpm.
+	- Run `pnpm install --frozen-lockfile` inside `frontend/`.
+	- Build with `pnpm run build` to create the `dist/` bundle.
+	- Lint with `pnpm lint` and run TypeScript checks with `pnpm typecheck`.
+	- Run frontend unit tests with `pnpm test:unit`.
 3. **API**:
-   - Requires Go 1.21+ and Mage.
-   - If the frontend bundle is missing, create one or a dummy file with `mkdir -p frontend/dist && touch frontend/dist/index.html`.
-   - Build with `mage build`.
-   - Lint with `mage lint` and run `mage check:translations` when translation files change.
+	- Requires Go 1.23+ and Mage.
+	- If the frontend bundle is missing, create one or a dummy file with `mkdir -p frontend/dist && touch frontend/dist/index.html`.
+	- Build with `mage build`.
+	- Lint with `mage lint` and run `mage check:translations` when translation files change.
 4. Cross‑compile with `mage release` or `mage release:{linux|windows|darwin}`.
 
 ## Testing
 - Set `VIKUNJA_SERVICE_ROOTPATH` to the repository root before running tests so fixtures load correctly.
 - Run API unit tests with `mage test:unit`.
 - Run API integration tests with `mage test:integration`.
-- Run frontend unit tests with `pnpm test:unit`.
+- Run frontend unit tests with `pnpm test:unit` (run `pnpm install --frozen-lockfile` in `frontend/` first).
+- Run `pnpm lint` and `pnpm typecheck` to match CI checks.
 
 ## Pull Requests
 - PRs must be opened on our [Gitea instance](https://kolaente.dev/vikunja) against the `main` branch.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <img src="https://vikunja.io/images/vikunja-logo.svg" alt="" style="display: block;width: 50%;margin: 0 auto;" width="50%"/>
 
 [![Build Status](https://drone.kolaente.de/api/badges/vikunja/vikunjaa/status.svg)](https://drone.kolaente.de/vikunja/vikunja)
-[![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE)
+[![License: AGPL-3.0-or-later](https://img.shields.io/badge/License-AGPL--3.0--or--later-blue.svg)](LICENSE)
 [![Install](https://img.shields.io/badge/download-v0.24.6-brightgreen.svg)](https://vikunja.io/docs/installing)
 [![Docker Pulls](https://img.shields.io/docker/pulls/vikunja/vikunja.svg)](https://hub.docker.com/r/vikunja/vikunja/)
 [![Swagger Docs](https://img.shields.io/badge/swagger-docs-brightgreen.svg)](https://try.vikunja.io/api/v1/docs)
@@ -52,4 +52,4 @@ Please check out the contribuition guidelines on [the website](https://vikunja.i
 
 ## License
 
-This project is licensed under the AGPLv3 License. See the [LICENSE](LICENSE) file for the full license text.
+This project is licensed under the AGPL-3.0-or-later license. See the [LICENSE](LICENSE) file for the details.

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -1,6 +1,6 @@
 # Vikunja desktop
 
-[![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](LICENSE)
+[![License: GPL-3.0-or-later](https://img.shields.io/badge/License-GPL--3.0--or--later-blue.svg)](LICENSE)
 
 The Vikunja frontend all repackaged as an electron app to run as a desktop app!
 
@@ -38,3 +38,7 @@ pnpm start
 2. Change the version in `package.json` (That's the one that will be used by electron-builder`
 3. `pnpm install`
 4. `pnpm run dist --linux --windows`
+
+## License
+
+This project is licensed under the GPL-3.0-or-later license. See the [LICENSE](LICENSE) file for details.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,7 +2,7 @@
 
 > The todo app to organize your life.
 
-[![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE)
+[![License: AGPL-3.0-or-later](https://img.shields.io/badge/License-AGPL--3.0--or--later-blue.svg)](LICENSE)
 [![Translation](https://badges.crowdin.net/vikunja/localized.svg)](https://crowdin.com/project/vikunja)
 
 This is the web frontend for Vikunja, written in Vue.js.
@@ -49,3 +49,7 @@ pnpm run build
 ```shell
 pnpm run lint
 ```
+
+## License
+
+This project is licensed under the AGPL-3.0-or-later license. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- clarify license badge text and update license notes

## Testing
- `mage test:unit` *(fails: signal interrupt)*
- `mage test:integration` *(fails: signal interrupt)*
- `pnpm lint` in `frontend`
- `pnpm typecheck` in `frontend` *(fails: command failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_6843d870c59c83208cf1bcb46532d9fd