### PR TITLE
Fix Docker license label and include AGPL text

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ LABEL org.opencontainers.image.authors='maintainers@vikunja.io'
 LABEL org.opencontainers.image.url='https://vikunja.io'
 LABEL org.opencontainers.image.documentation='https://vikunja.io/docs'
 LABEL org.opencontainers.image.source='https://code.vikunja.io/vikunja'
-LABEL org.opencontainers.image.licenses='AGPLv3'
+LABEL org.opencontainers.image.licenses='AGPL-3.0-or-later'
 LABEL org.opencontainers.image.title='Vikunja'
 
 WORKDIR /app/vikunja
@@ -56,3 +56,4 @@ ENV VIKUNJA_DATABASE_PATH=/db/vikunja.db
 
 COPY --from=apibuilder /build/vikunja-* vikunja
 COPY --from=apibuilder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY LICENSE /LICENSE


### PR DESCRIPTION
## Summary
- update `org.opencontainers.image.licenses` label to `AGPL-3.0-or-later`
- copy the project's LICENSE file into the container image

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Argument of type errors)*
- `pnpm test:unit` *(fails: exit code 130 due to interactive mode)*
- `mage lint` *(fails: signal interrupt)*
- `mage test:unit` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6843d8533a0883208143034d529589b6