### PR TITLE
docs: describe updating fonts

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -49,3 +49,14 @@ pnpm run build
 ```shell
 pnpm run lint
 ```
+
+### Updating fonts
+
+To regenerate the bundled fonts run the following from the `frontend/` directory:
+
+```bash
+pnpm fonts:update
+```
+
+Run this whenever you change `src/styles/fonts.scss` or update the fonts in
+`originalMedia/fonts`. The subsetting script uses fonttools and requires **Bash**.

--- a/frontend/scripts/fonts-download.sh
+++ b/frontend/scripts/fonts-download.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 #

--- a/frontend/scripts/fonts-subset.sh
+++ b/frontend/scripts/fonts-subset.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 #

--- a/frontend/src/styles/fonts.scss
+++ b/frontend/src/styles/fonts.scss
@@ -1,5 +1,8 @@
 $font-files-path: '@/assets/fonts/';
 
+// Run `pnpm fonts:update` whenever fonts or this file changes to regenerate
+// the font subsets. The underlying script requires Bash.
+
 // this is the same as the latin range that google uses.
 // see for examle the unicode-range definition here:
 // https://fonts.googleapis.com/css2?family=Open+Sans
@@ -103,3 +106,4 @@ $unicode-range: "U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,\
     unicode-range: $unicode-range;
   }
 }
+


### PR DESCRIPTION
## Summary
- note how to run the font subsetting script
- require Bash in font scripts and add docs comment in the stylesheet

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm typecheck` *(fails: Cannot find name 'Ref')*
- `pnpm test:unit` *(fails: Command failed with exit code 130)*
- `mage test:unit` *(fails: command not found)*
- `mage test:integration` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684414a5959083209b35bbcb266d034e