### PR TITLE
Include LICENSE in packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS
+
+These instructions summarize the development guidelines from the official Vikunja docs and CI workflows. They apply to the entire repository.
+
+## Development Environment
+- Use [devenv](https://devenv.sh/) to get a shell with all required tools.
+
+## Building From Source
+1. Clone the repo and check out the desired version.
+2. **Frontend**:
+   - Requires Node.js 20+ and pnpm.
+   - Run `pnpm install` inside `frontend/`.
+   - Build with `pnpm run build` to create the `dist/` bundle.
+   - Lint with `pnpm lint` and run TypeScript checks with `pnpm typecheck`.
+   - Run frontend unit tests with `pnpm test:unit`.
+3. **API**:
+   - Requires Go 1.21+ and Mage.
+   - If the frontend bundle is missing, create one or a dummy file with `mkdir -p frontend/dist && touch frontend/dist/index.html`.
+   - Build with `mage build`.
+   - Lint with `mage lint` and run `mage check:translations` when translation files change.
+4. Cross‑compile with `mage release` or `mage release:{linux|windows|darwin}`.
+
+## Testing
+- Set `VIKUNJA_SERVICE_ROOTPATH` to the repository root before running tests so fixtures load correctly.
+- Run API unit tests with `mage test:unit`.
+- Run API integration tests with `mage test:integration`.
+- Run frontend unit tests with `pnpm test:unit`.
+
+## Pull Requests
+- PRs must be opened on our [Gitea instance](https://kolaente.dev/vikunja) against the `main` branch.
+- Keep PRs small and focused. Allow maintainers to edit your branch.
+- Describe the problem in the PR title and provide a summary in the first comment.
+- If the PR changes the UI, include after screenshots.
+- Reference issues with `Fixes/Closes/Resolves #<number>` each on its own line.
+- Conventional Commit messages are appreciated but not mandatory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,27 +4,33 @@ These instructions summarize the development guidelines from the official Vikunj
 
 ## Development Environment
 - Use [devenv](https://devenv.sh/) to get a shell with all required tools.
+- Respect the formatting rules from `.editorconfig` in the repository root and
+        all subfolders.
+- The CI uses the Node.js version defined in `frontend/.nvmrc` (currently 22)
+        and Go 1.23 from `go.mod`.
 
 ## Building From Source
 1. Clone the repo and check out the desired version.
+
 2. **Frontend**:
-   - Requires Node.js 20+ and pnpm.
-   - Run `pnpm install` inside `frontend/`.
-   - Build with `pnpm run build` to create the `dist/` bundle.
-   - Lint with `pnpm lint` and run TypeScript checks with `pnpm typecheck`.
-   - Run frontend unit tests with `pnpm test:unit`.
+	- Requires Node.js 22+ and pnpm.
+	- Run `pnpm install --frozen-lockfile` inside `frontend/`.
+	- Build with `pnpm run build` to create the `dist/` bundle.
+	- Lint with `pnpm lint` and run TypeScript checks with `pnpm typecheck`.
+	- Run frontend unit tests with `pnpm test:unit`.
 3. **API**:
-   - Requires Go 1.21+ and Mage.
-   - If the frontend bundle is missing, create one or a dummy file with `mkdir -p frontend/dist && touch frontend/dist/index.html`.
-   - Build with `mage build`.
-   - Lint with `mage lint` and run `mage check:translations` when translation files change.
+	- Requires Go 1.23+ and Mage.
+	- If the frontend bundle is missing, create one or a dummy file with `mkdir -p frontend/dist && touch frontend/dist/index.html`.
+	- Build with `mage build`.
+	- Lint with `mage lint` and run `mage check:translations` when translation files change.
 4. Cross‑compile with `mage release` or `mage release:{linux|windows|darwin}`.
 
 ## Testing
 - Set `VIKUNJA_SERVICE_ROOTPATH` to the repository root before running tests so fixtures load correctly.
 - Run API unit tests with `mage test:unit`.
 - Run API integration tests with `mage test:integration`.
-- Run frontend unit tests with `pnpm test:unit`.
+- Run frontend unit tests with `pnpm test:unit` (run `pnpm install --frozen-lockfile` in `frontend/` first).
+- Run `pnpm lint` and `pnpm typecheck` to match CI checks.
 
 ## Pull Requests
 - PRs must be opened on our [Gitea instance](https://kolaente.dev/vikunja) against the `main` branch.

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -7,7 +7,7 @@ maintainer: "Vikunja Maintainers <maintainers@vikunja.io>"
 homepage: "https://vikunja.io"
 section: "default"
 priority: "extra"
-license: "AGPLv3"
+license: "AGPL-3.0-or-later"
 depends:
   - systemd
 contents:
@@ -16,6 +16,8 @@ contents:
   - src: ./config.yml.sample
     dst: /etc/vikunja/config.yml
     type: "config"
+  - src: ./LICENSE
+    dst: /usr/share/doc/vikunja/LICENSE
   - src: /opt/vikunja/vikunja
     dst: /usr/local/bin/vikunja
     type: "symlink"


### PR DESCRIPTION
## Summary
- add LICENSE file to package contents via nfpm
- specify `AGPL-3.0-or-later` in nfpm config

## Testing
- `mage test:unit` *(fails: `frontend/embed.go:21:12: pattern dist: no matching files found`)*
- `mage test:integration` *(fails to finish in environment)*
- `pnpm lint` *(fails: `Cannot find package 'eslint-plugin-vue'`)*
- `pnpm typecheck` *(fails: `vue-tsc: not found`)*
- `pnpm test:unit` *(fails: `vitest: not found`)*


------
https://chatgpt.com/codex/tasks/task_e_6843d864b1908320b0080487e2fd7614