### PR TITLE
Fix license wording in publiccode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS
+
+These instructions summarize the development guidelines from the official Vikunja docs and CI workflows. They apply to the entire repository.
+
+## Development Environment
+- Use [devenv](https://devenv.sh/) to get a shell with all required tools.
+
+## Building From Source
+1. Clone the repo and check out the desired version.
+2. **Frontend**:
+   - Requires Node.js 20+ and pnpm.
+   - Run `pnpm install` inside `frontend/`.
+   - Build with `pnpm run build` to create the `dist/` bundle.
+   - Lint with `pnpm lint` and run TypeScript checks with `pnpm typecheck`.
+   - Run frontend unit tests with `pnpm test:unit`.
+3. **API**:
+   - Requires Go 1.21+ and Mage.
+   - If the frontend bundle is missing, create one or a dummy file with `mkdir -p frontend/dist && touch frontend/dist/index.html`.
+   - Build with `mage build`.
+   - Lint with `mage lint` and run `mage check:translations` when translation files change.
+4. Cross‑compile with `mage release` or `mage release:{linux|windows|darwin}`.
+
+## Testing
+- Set `VIKUNJA_SERVICE_ROOTPATH` to the repository root before running tests so fixtures load correctly.
+- Run API unit tests with `mage test:unit`.
+- Run API integration tests with `mage test:integration`.
+- Run frontend unit tests with `pnpm test:unit`.
+
+## Pull Requests
+- PRs must be opened on our [Gitea instance](https://kolaente.dev/vikunja) against the `main` branch.
+- Keep PRs small and focused. Allow maintainers to edit your branch.
+- Describe the problem in the PR title and provide a summary in the first comment.
+- If the PR changes the UI, include after screenshots.
+- Reference issues with `Fixes/Closes/Resolves #<number>` each on its own line.
+- Conventional Commit messages are appreciated but not mandatory.

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -44,7 +44,7 @@ screenshots:
 videos:
   - 'none'
 legal:
-  license: 'GNU AFFERO GENERAL PUBLIC LICENSE Version 3'
+  license: 'GNU Affero General Public License v3 or later.'
   mainCopyrightOwner: 'Konrad Langenberg Software'
   repoOwner: 'Konrad Langenberg Software'
   authorsFile: 'hello@vikunja.io'


### PR DESCRIPTION
## Summary
- fix license entry in `publiccode.yml`

## Testing
- `mage test:unit` *(fails: pattern dist: no matching files found)*
- `mage test:integration` *(fails: signal interrupt)*
- `pnpm test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843cdd8aa4c832086b17006254790d4