### PR TITLE
Remove setTitle helper and use useTitle composable

### DIFF
--- a/frontend/src/helpers/setTitle.ts
+++ b/frontend/src/helpers/setTitle.ts
@@ -1,5 +1,0 @@
-export function setTitle(title : undefined | string) {
-	document.title = (typeof title === 'undefined' || title === '')
-		? 'Vikunja'
-		: `${title} | Vikunja`
-}

--- a/frontend/src/views/tasks/ShowTasks.vue
+++ b/frontend/src/views/tasks/ShowTasks.vue
@@ -74,7 +74,7 @@ import {useRoute, useRouter} from 'vue-router'
 import {useI18n} from 'vue-i18n'
 
 import {formatDate} from '@/helpers/time/formatDate'
-import {setTitle} from '@/helpers/setTitle'
+import {useTitle} from '@/composables/useTitle'
 
 import FancyCheckbox from '@/components/input/FancyCheckbox.vue'
 import SingleTaskInProject from '@/components/tasks/partials/SingleTaskInProject.vue'
@@ -232,7 +232,7 @@ function updateTasks(updatedTask: ITask) {
 }
 
 watchEffect(() => loadPendingTasks(props.dateFrom, props.dateTo))
-watchEffect(() => setTitle(pageTitle.value))
+useTitle(pageTitle)
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
## Summary
- remove obsolete helper `setTitle.ts`
- use the `useTitle` composable in `ShowTasks.vue`

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: many existing TS errors)*
- `pnpm test:unit` *(tests pass but process exited with code 130 when cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_684439fd32688320a15771da07f50570