### PR TITLE
Refactor local state to use useStorage

### DIFF
--- a/frontend/src/components/project/views/ProjectKanban.vue
+++ b/frontend/src/components/project/views/ProjectKanban.vue
@@ -296,9 +296,8 @@ import Dropdown from '@/components/misc/Dropdown.vue'
 import DropdownItem from '@/components/misc/DropdownItem.vue'
 
 import {
-	type CollapsedBuckets,
-	getCollapsedBucketState,
-	saveCollapsedBucketState,
+       type CollapsedBuckets,
+       collapsedBucketState,
 } from '@/helpers/saveCollapsedBucketState'
 import {calculateItemPosition} from '@/helpers/calculateItemPosition'
 
@@ -415,8 +414,8 @@ watch(
 		if (projectId === undefined || Number(projectId) === 0) {
 			return
 		}
-		collapsedBuckets.value = getCollapsedBucketState(projectId)
-		kanbanStore.loadBucketsForProject(projectId, viewId, params)
+               collapsedBuckets.value = collapsedBucketState.value[projectId] ?? {}
+               kanbanStore.loadBucketsForProject(projectId, viewId, params)
 	},
 	{
 		immediate: true,
@@ -772,8 +771,8 @@ async function toggleDoneBucket(bucket: IBucket) {
 }
 
 function collapseBucket(bucket: IBucket) {
-	collapsedBuckets.value[bucket.id] = true
-	saveCollapsedBucketState(project.value.id, collapsedBuckets.value)
+        collapsedBuckets.value[bucket.id] = true
+       collapsedBucketState.value[project.value.id] = collapsedBuckets.value
 }
 
 function unCollapseBucket(bucket: IBucket) {
@@ -781,8 +780,8 @@ function unCollapseBucket(bucket: IBucket) {
 		return
 	}
 
-	collapsedBuckets.value[bucket.id] = false
-	saveCollapsedBucketState(project.value.id, collapsedBuckets.value)
+        collapsedBuckets.value[bucket.id] = false
+       collapsedBucketState.value[project.value.id] = collapsedBuckets.value
 }
 </script>
 

--- a/frontend/src/components/quick-actions/QuickActions.vue
+++ b/frontend/src/components/quick-actions/QuickActions.vue
@@ -118,7 +118,7 @@ import {useLabelStore} from '@/stores/labels'
 import {useTaskStore} from '@/stores/tasks'
 import {useAuthStore} from '@/stores/auth'
 
-import {getHistory} from '@/modules/projectHistory'
+import {projectHistory as projectHistoryRef} from '@/modules/projectHistory'
 import {parseTaskText, PREFIXES, PrefixMode} from '@/modules/parseTaskText'
 import {success} from '@/message'
 
@@ -193,11 +193,11 @@ const foundProjects = computed(() => {
 		return []
 	}
 
-	if (text === '') {
-		const history = getHistory()
-		return history.map((p) => projectStore.projects[p.id])
-			.filter(p => Boolean(p))
-	}
+       if (text === '') {
+               const history = projectHistoryRef.value
+               return history.map((p) => projectStore.projects[p.id])
+                       .filter(p => Boolean(p))
+       }
 
 	return projectStore.searchProjectAndFilter(project ?? text)
 		.filter(p => Boolean(p))

--- a/frontend/src/composables/useRedirectToLastVisited.ts
+++ b/frontend/src/composables/useRedirectToLastVisited.ts
@@ -1,22 +1,22 @@
 import {useRouter} from 'vue-router'
-import {getLastVisited, clearLastVisited} from '@/helpers/saveLastVisited'
+import {lastVisited} from '@/helpers/saveLastVisited'
 
 export function useRedirectToLastVisited() {
 
-	const router = useRouter()
+       const router = useRouter()
 
-	function getLastVisitedRoute() {
-		const last = getLastVisited()
-		if (last === null) {
-			return null
-		}
+       function getLastVisitedRoute() {
+               const last = lastVisited.value
+               if (last === null) {
+                       return null
+               }
 
-		clearLastVisited()
-		return {
-			name: last.name,
-			params: last.params,
-			query: last.query,
-		}
+               lastVisited.value = null
+               return {
+                       name: last.name,
+                       params: last.params,
+                       query: last.query,
+               }
 	}
 
 	function redirectIfSaved() {

--- a/frontend/src/helpers/saveCollapsedBucketState.ts
+++ b/frontend/src/helpers/saveCollapsedBucketState.ts
@@ -1,34 +1,10 @@
 import type {IBucket} from '@/modelTypes/IBucket'
 import type {IProject} from '@/modelTypes/IProject'
+import {useStorage} from '@vueuse/core'
 
 const key = 'collapsedBuckets'
 
 export type CollapsedBuckets = {[id: IBucket['id']]: boolean}
+export type CollapsedBucketState = { [id: IProject['id']]: CollapsedBuckets }
 
-function getAllState() {
-	const saved = localStorage.getItem(key)
-	return saved === null
-		? {}
-		: JSON.parse(saved)
-}
-
-export const saveCollapsedBucketState = (
-	projectId: IProject['id'],
-	collapsedBuckets: CollapsedBuckets,
-) => {
-	const state = getAllState()
-	state[projectId] = collapsedBuckets
-	for (const bucketId in state[projectId]) {
-		if (!state[projectId][bucketId]) {
-			delete state[projectId][bucketId]
-		}
-	}
-	localStorage.setItem(key, JSON.stringify(state))
-}
-
-export function getCollapsedBucketState(projectId : IProject['id']) {
-	const state = getAllState()
-	return typeof state[projectId] !== 'undefined'
-		? state[projectId]
-		: {}
-}
+export const collapsedBucketState = useStorage<CollapsedBucketState>(key, {})

--- a/frontend/src/helpers/saveLastVisited.ts
+++ b/frontend/src/helpers/saveLastVisited.ts
@@ -1,22 +1,11 @@
+import {useStorage} from '@vueuse/core'
+
 const LAST_VISITED_KEY = 'lastVisited'
 
-export const saveLastVisited = (name: string | undefined, params: object, query: object) => {
-	if (typeof name === 'undefined') {
-		return
-	}
-	
-	localStorage.setItem(LAST_VISITED_KEY, JSON.stringify({name, params, query}))
+export interface LastVisited {
+       name: string
+       params: object
+       query: object
 }
 
-export const getLastVisited = () => {
-	const lastVisited = localStorage.getItem(LAST_VISITED_KEY)
-	if (lastVisited === null) {
-		return null
-	}
-
-	return JSON.parse(lastVisited)
-}
-
-export const clearLastVisited = () => {
-	return localStorage.removeItem(LAST_VISITED_KEY)
-}
+export const lastVisited = useStorage<LastVisited | null>(LAST_VISITED_KEY, null)

--- a/frontend/src/modules/projectHistory.test.ts
+++ b/frontend/src/modules/projectHistory.test.ts
@@ -1,83 +1,52 @@
-import {test, expect, vi} from 'vitest'
-import {getHistory, removeProjectFromHistory, saveProjectToHistory} from './projectHistory'
+import {beforeEach, test, expect} from 'vitest'
+import {projectHistory, saveProjectToHistory, removeProjectFromHistory} from './projectHistory'
+
+beforeEach(() => {
+        projectHistory.value = []
+})
 
 test('return an empty history when none was saved', () => {
-	vi.spyOn(localStorage, 'getItem').mockImplementation(() => null)
-	const h = getHistory()
-	expect(h).toStrictEqual([])
+        expect(projectHistory.value).toStrictEqual([])
 })
 
 test('return a saved history', () => {
-	const saved = [{id: 1}, {id: 2}]
-	vi.spyOn(localStorage, 'getItem').mockImplementation(() => JSON.stringify(saved))
-
-	const h = getHistory()
-	expect(h).toStrictEqual(saved)
+        projectHistory.value = [{id: 1}, {id: 2}]
+        expect(projectHistory.value).toStrictEqual([{id: 1}, {id: 2}])
 })
 
 test('store project in history', () => {
-	let saved = {}
-	vi.spyOn(localStorage, 'getItem').mockImplementation(() => null)
-	vi.spyOn(localStorage, 'setItem').mockImplementation((key: string, projects: string) => {
-		saved = projects
-	})
-
-	saveProjectToHistory({id: 1})
-	expect(saved).toBe('[{"id":1}]')
+        saveProjectToHistory({id: 1})
+        expect(projectHistory.value).toStrictEqual([{id: 1}])
 })
 
 test('store only the last 6 projects in history', () => {
-	let saved: string | null = null
-	vi.spyOn(localStorage, 'getItem').mockImplementation(() => saved)
-	vi.spyOn(localStorage, 'setItem').mockImplementation((key: string, projects: string) => {
-		saved = projects
-	})
-
-	saveProjectToHistory({id: 1})
-	saveProjectToHistory({id: 2})
-	saveProjectToHistory({id: 3})
-	saveProjectToHistory({id: 4})
-	saveProjectToHistory({id: 5})
-	saveProjectToHistory({id: 6})
-	saveProjectToHistory({id: 7})
-	expect(saved).toBe('[{"id":7},{"id":6},{"id":5},{"id":4},{"id":3},{"id":2}]')
+        saveProjectToHistory({id: 1})
+        saveProjectToHistory({id: 2})
+        saveProjectToHistory({id: 3})
+        saveProjectToHistory({id: 4})
+        saveProjectToHistory({id: 5})
+        saveProjectToHistory({id: 6})
+        saveProjectToHistory({id: 7})
+        expect(projectHistory.value).toStrictEqual([
+                {id: 7}, {id: 6}, {id: 5}, {id: 4}, {id: 3}, {id: 2},
+        ])
 })
 
-test('don\'t store the same project twice', () => {
-	let saved: string | null = null
-	vi.spyOn(localStorage, 'getItem').mockImplementation(() => saved)
-	vi.spyOn(localStorage, 'setItem').mockImplementation((key: string, projects: string) => {
-		saved = projects
-	})
-
-	saveProjectToHistory({id: 1})
-	saveProjectToHistory({id: 1})
-	expect(saved).toBe('[{"id":1}]')
+test("don't store the same project twice", () => {
+        saveProjectToHistory({id: 1})
+        saveProjectToHistory({id: 1})
+        expect(projectHistory.value).toStrictEqual([{id: 1}])
 })
 
 test('move a project to the beginning when storing it multiple times', () => {
-	let saved: string | null = null
-	vi.spyOn(localStorage, 'getItem').mockImplementation(() => saved)
-	vi.spyOn(localStorage, 'setItem').mockImplementation((key: string, projects: string) => {
-		saved = projects
-	})
-
-	saveProjectToHistory({id: 1})
-	saveProjectToHistory({id: 2})
-	saveProjectToHistory({id: 1})
-	expect(saved).toBe('[{"id":1},{"id":2}]')
+        saveProjectToHistory({id: 1})
+        saveProjectToHistory({id: 2})
+        saveProjectToHistory({id: 1})
+        expect(projectHistory.value).toStrictEqual([{id: 1}, {id: 2}])
 })
 
 test('remove project from history', () => {
-	let saved: string | null = '[{"id": 1}]'
-	vi.spyOn(localStorage, 'getItem').mockImplementation(() => saved)
-	vi.spyOn(localStorage, 'setItem').mockImplementation((key: string, projects: string) => {
-		saved = projects
-	})
-	vi.spyOn(localStorage, 'removeItem').mockImplementation((key: string) => {
-		saved = null
-	})
-
-	removeProjectFromHistory({id: 1})
-	expect(saved).toBeNull()
+        saveProjectToHistory({id: 1})
+        removeProjectFromHistory({id: 1})
+        expect(projectHistory.value).toStrictEqual([])
 })

--- a/frontend/src/modules/projectHistory.ts
+++ b/frontend/src/modules/projectHistory.ts
@@ -1,29 +1,15 @@
+import {useStorage} from '@vueuse/core'
+
 export interface ProjectHistory {
-	id: number;
+       id: number;
 }
 
-export function getHistory(): ProjectHistory[] {
-	const savedHistory = localStorage.getItem('projectHistory')
-	if (savedHistory === null) {
-		return []
-	}
-
-	return JSON.parse(savedHistory)
-}
-
-function saveHistory(history: ProjectHistory[]) {
-	if (history.length === 0) {
-		localStorage.removeItem('projectHistory')
-		return
-	}
-
-	localStorage.setItem('projectHistory', JSON.stringify(history))
-}
+export const projectHistory = useStorage<ProjectHistory[]>('projectHistory', [])
 
 const MAX_SAVED_PROJECTS = 6
 
 export function saveProjectToHistory(project: ProjectHistory) {
-	const history: ProjectHistory[] = getHistory()
+       const history: ProjectHistory[] = projectHistory.value
 
 	// Remove the element if it already exists in history, preventing duplicates and essentially moving it to the beginning
 	history.forEach((l, i) => {
@@ -38,16 +24,16 @@ export function saveProjectToHistory(project: ProjectHistory) {
 	if (history.length > MAX_SAVED_PROJECTS) {
 		history.pop()
 	}
-	saveHistory(history)
+       projectHistory.value = history
 }
 
 export function removeProjectFromHistory(project: ProjectHistory) {
-	const history: ProjectHistory[] = getHistory()
+       const history: ProjectHistory[] = projectHistory.value
 
 	history.forEach((l, i) => {
 		if (l.id === project.id) {
 			history.splice(i, 1)
 		}
 	})
-	saveHistory(history)
+       projectHistory.value = history
 }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,6 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import type { RouteLocation } from 'vue-router'
-import {saveLastVisited} from '@/helpers/saveLastVisited'
+import {lastVisited} from '@/helpers/saveLastVisited'
 
 import {getProjectViewId} from '@/helpers/projectView'
 import {parseDateOrString} from '@/helpers/time/parseDateOrString'
@@ -417,9 +417,9 @@ export async function getAuthForRoute(to: RouteLocation, authStore) {
 		].includes(to.name as string) &&
 		localStorage.getItem('emailConfirmToken') === null
 	
-	if (isValidUserAppRoute) {
-		saveLastVisited(to.name as string, to.params, to.query)
-	}
+       if (isValidUserAppRoute) {
+               lastVisited.value = {name: to.name as string, params: to.params, query: to.query}
+       }
 	
 	if (isValidUserAppRoute) {
 		return {name: 'user.login'}
@@ -437,14 +437,14 @@ router.beforeEach(async (to, from) => {
 		to.hash = from.hash
 	}
 
-	if (to.hash.startsWith(LINK_SHARE_HASH_PREFIX) && !authStore.authLinkShare) {
-		saveLastVisited(to.name as string, to.params, to.query)
-		return {
-			name: 'link-share.auth',
-			params: {
-				share: to.hash.replace(LINK_SHARE_HASH_PREFIX, ''),
-			},
-		}
+       if (to.hash.startsWith(LINK_SHARE_HASH_PREFIX) && !authStore.authLinkShare) {
+               lastVisited.value = {name: to.name as string, params: to.params, query: to.query}
+               return {
+                       name: 'link-share.auth',
+                       params: {
+                               share: to.hash.replace(LINK_SHARE_HASH_PREFIX, ''),
+                       },
+               }
 	}
 
 	const newRoute = await getAuthForRoute(to, authStore)

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -53,7 +53,7 @@ import ProjectCardGrid from '@/components/project/partials/ProjectCardGrid.vue'
 import AddTask from '@/components/tasks/AddTask.vue'
 import ImportHint from '@/components/home/ImportHint.vue'
 
-import {getHistory} from '@/modules/projectHistory'
+import {projectHistory as projectHistoryRef} from '@/modules/projectHistory'
 import {parseDateOrNull} from '@/helpers/parseDateOrNull'
 import {formatDateShort, formatDateSince} from '@/helpers/time/formatDate'
 import {useDaytimeSalutation} from '@/composables/useDaytimeSalutation'
@@ -67,14 +67,14 @@ const authStore = useAuthStore()
 const projectStore = useProjectStore()
 
 const projectHistory = computed(() => {
-	// If we don't check this, it tries to load the project background right after logging out	
-	if(!authStore.authenticated) {
-		return []
-	}
-	
-	return getHistory()
-		.map(l => projectStore.projects[l.id])
-		.filter(l => Boolean(l))
+       // If we don't check this, it tries to load the project background right after logging out
+       if(!authStore.authenticated) {
+               return []
+       }
+
+       return projectHistoryRef.value
+               .map(l => projectStore.projects[l.id])
+               .filter(l => Boolean(l))
 })
 
 const tasksLoaded = ref(false)


### PR DESCRIPTION
## Summary
- refactor collapsed bucket state to use `useStorage`
- use `useStorage` for storing last visited route
- keep project history in a reactive reference via `useStorage`
- adjust consuming code to work with reactive refs
- update unit tests

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Argument of type errors in unrelated files)*
- `pnpm test:unit` *(fails: process exited with code 130 after tests pass)*
- `mage lint` *(fails: command not found)*
- `mage test:unit` *(fails: command not found)*
- `mage test:integration` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684439eb3abc83209c7c03ff48ab3af0