### PR TITLE
Fix dynamic register route

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -10,7 +10,6 @@ import {LINK_SHARE_HASH_PREFIX} from '@/constants/linkShareHash'
 import {useAuthStore} from '@/stores/auth'
 
 import Login from '@/views/user/Login.vue'
-import Register from '@/views/user/Register.vue'
 import LinkSharingAuth from '@/views/sharing/LinkSharingAuth.vue'
 import OpenIdAuth from '@/views/user/OpenIdAuth.vue'
 import UpcomingTasks from '@/views/tasks/ShowTasks.vue'
@@ -74,16 +73,21 @@ const router = createRouter({
 				title: 'user.auth.resetPassword',
 			},
 		},
-		{
-			path: '/register',
-			name: 'user.register',
-			// FIXME: use dynamic imports
-			// component: () => import('@/views/user/Register.vue'),
-			component: Register,
-			meta: {
-				title: 'user.auth.createAccount',
-			},
-		},
+               {
+                       path: '/register',
+                       name: 'user.register',
+                       component: () => import('@/views/user/Register.vue'),
+                       meta: {
+                               title: 'user.auth.createAccount',
+                       },
+                       async beforeEnter() {
+                               const authStore = useAuthStore()
+                               await authStore.checkAuth()
+                               if (authStore.authenticated) {
+                                       return {name: 'home'}
+                               }
+                       },
+               },
 		{
 			path: '/user/settings',
 			name: 'user.settings',

--- a/frontend/src/views/user/Register.vue
+++ b/frontend/src/views/user/Register.vue
@@ -117,10 +117,9 @@
 
 <script setup lang="ts">
 import {useDebounceFn} from '@vueuse/core'
-import {computed, onBeforeMount, reactive, ref, toRaw} from 'vue'
+import {computed, reactive, ref, toRaw} from 'vue'
 import {useI18n} from 'vue-i18n'
 
-import router from '@/router'
 import Message from '@/components/misc/Message.vue'
 import {isEmail} from '@/helpers/isEmail'
 import Password from '@/components/input/Password.vue'
@@ -132,14 +131,6 @@ import {validatePassword} from '@/helpers/validatePasswort'
 const {t} = useI18n()
 const authStore = useAuthStore()
 const configStore = useConfigStore()
-
-// FIXME: use the `beforeEnter` hook of vue-router
-// Check if the user is already logged in, if so, redirect them to the homepage
-onBeforeMount(() => {
-	if (authStore.authenticated) {
-		router.push({name: 'home'})
-	}
-})
 
 const credentials = reactive({
 	username: '',


### PR DESCRIPTION
## Summary
- use a beforeEnter hook to check auth status before showing `/register`
- re-enable dynamic import for the register view and drop the FIXME
- clean up onBeforeMount check in `Register.vue`

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Argument of type '{}' is not assignable to parameter of type 'ICaldavToken' etc.)*
- `pnpm test:unit`
- `mage lint` *(failed: signal: interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6844a548b5908320a37dd9ff5741d9ba