### PR TITLE
Update JWT secret docs and safer CORS defaults

### DIFF
--- a/config-raw.json
+++ b/config-raw.json
@@ -6,7 +6,7 @@
                 {
                     "key": "JWTSecret",
                     "default_value": "\u003cjwt-secret\u003e",
-                    "comment": "This token is used to verify issued JWT tokens.\nDefault is a random token which will be generated at each startup of Vikunja.\n(This means all already issued tokens will be invalid once you restart Vikunja)"
+                    "comment": "Token used to sign and verify issued JWT tokens.\nSet the `VIKUNJA_SERVICE_JWTSECRET` environment variable to a random secret to keep tokens valid across restarts."
                 },
                 {
                     "key": "jwtttl",
@@ -295,12 +295,8 @@
                 },
                 {
                     "key": "origins",
-                    "comment": "A list of origins which may access the api. These need to include the protocol (`http://` or `https://`) and port, if any.",
-                    "children": [
-                        {
-                            "default_value": "*"
-                        }
-                    ]
+                    "comment": "A list of allowed origins for CORS requests. Include the protocol and port if any.\nLeave empty to deny cross-origin requests.",
+                    "children": []
                 },
                 {
                     "key": "maxage",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -38,7 +38,6 @@ type Key string
 
 // These constants hold all config value keys
 const (
-	// #nosec
 	ServiceJWTSecret                      Key = `service.JWTSecret`
 	ServiceJWTTTL                         Key = `service.jwtttl`
 	ServiceJWTTTLLong                     Key = `service.jwtttllong`
@@ -422,7 +421,7 @@ func InitDefaultConfig() {
 	FilesMaxSize.setDefault("20MB")
 	// Cors
 	CorsEnable.setDefault(false)
-	CorsOrigins.setDefault([]string{"*"})
+	CorsOrigins.setDefault([]string{})
 	CorsMaxAge.setDefault(0)
 	// Migration
 	MigrationTodoistEnable.setDefault(false)


### PR DESCRIPTION
## Summary
- stop ignoring gosec warnings for ServiceJWTSecret
- set default CORS origins to empty
- document using `VIKUNJA_SERVICE_JWTSECRET` and how to configure CORS origins

## Testing
- `mage lint` *(fails: Potential hardcoded credentials)*
- `mage test:unit`


------
https://chatgpt.com/codex/tasks/task_e_6844bd530b088320b482517113da867d