### PR TITLE
Add link share type enum

### DIFF
--- a/frontend/cypress/factories/link_sharing.ts
+++ b/frontend/cypress/factories/link_sharing.ts
@@ -1,5 +1,6 @@
 import {Factory} from '../support/factory'
 import {faker} from '@faker-js/faker'
+import {LINK_SHARE_TYPES} from '@/constants/linkShareTypes'
 
 export class LinkShareFactory extends Factory {
 	static table = 'link_shares'
@@ -11,8 +12,8 @@ export class LinkShareFactory extends Factory {
 			id: '{increment}',
 			hash: faker.lorem.word(32),
 			project_id: 1,
-			right: 0,
-			sharing_type: 0,
+                       right: 0,
+                       sharing_type: LINK_SHARE_TYPES.UNKNOWN,
 			shared_by_id: 1,
 			created: now.toISOString(),
 			updated: now.toISOString(),

--- a/frontend/src/constants/linkShareTypes.ts
+++ b/frontend/src/constants/linkShareTypes.ts
@@ -1,0 +1,7 @@
+export const LINK_SHARE_TYPES = {
+  'UNKNOWN': 0,
+  'WITHOUT_PASSWORD': 1,
+  'WITH_PASSWORD': 2,
+} as const
+
+export type LinkShareType = typeof LINK_SHARE_TYPES[keyof typeof LINK_SHARE_TYPES]

--- a/frontend/src/modelTypes/ILinkShare.ts
+++ b/frontend/src/modelTypes/ILinkShare.ts
@@ -1,13 +1,14 @@
 import type {IAbstract} from './IAbstract'
 import type {IUser} from './IUser'
-import type { Right } from '@/constants/rights'
+import type {Right} from '@/constants/rights'
+import type {LinkShareType} from '@/constants/linkShareTypes'
 
 export interface ILinkShare extends IAbstract {
 	id: number
 	hash: string
 	right: Right
 	sharedBy: IUser
-	sharingType: number // FIXME: use correct numbers
+       sharingType: LinkShareType
 	projectId: number
 	name: string
 	password: string

--- a/frontend/src/models/linkShare.ts
+++ b/frontend/src/models/linkShare.ts
@@ -2,6 +2,7 @@ import AbstractModel from './abstractModel'
 import UserModel from './user'
 
 import {RIGHTS, type Right} from '@/constants/rights'
+import {LINK_SHARE_TYPES, type LinkShareType} from '@/constants/linkShareTypes'
 import type {ILinkShare} from '@/modelTypes/ILinkShare'
 import type {IUser} from '@/modelTypes/IUser'
 
@@ -10,7 +11,7 @@ export default class LinkShareModel extends AbstractModel<ILinkShare> implements
 	hash = ''
 	right: Right = RIGHTS.READ
 	sharedBy: IUser = UserModel
-	sharingType = 0 // FIXME: use correct numbers
+       sharingType: LinkShareType = LINK_SHARE_TYPES.UNKNOWN
 	projectId = 0
 	name: ''
 	password: ''


### PR DESCRIPTION
## Summary
- add LINK_SHARE_TYPES constant and type
- use the new type in `LinkShareModel` and `ILinkShare`
- update link sharing factory for cypress tests

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Caldav, Deletion, General, TOTP vue errors)*
- `pnpm vitest run --dir ./src`

------
https://chatgpt.com/codex/tasks/task_e_6844bf8f1db88320ab3d5cf0113f2cbf