### PR TITLE
Support RFC3339 timestamps in CalDAV parser

### DIFF
--- a/pkg/caldav/parsing.go
+++ b/pkg/caldav/parsing.go
@@ -443,6 +443,17 @@ func caldavTimeToTimestamp(ianaProperty ics.IANAProperty) time.Time {
 		return time.Time{}
 	}
 
+	// Try to parse RFC3339 timestamps first when the value contains a '-' or ':'
+	// as these are not part of the compact CalDAV date format.
+	if strings.ContainsAny(tstring, "-:") {
+		if t, err := time.Parse(time.RFC3339, tstring); err == nil {
+			return t.In(config.GetTimeZone())
+		}
+		if t, err := time.Parse(time.RFC3339Nano, tstring); err == nil {
+			return t.In(config.GetTimeZone())
+		}
+	}
+
 	format := DateFormat
 
 	if strings.HasSuffix(tstring, "Z") {
@@ -465,8 +476,7 @@ func caldavTimeToTimestamp(ianaProperty ics.IANAProperty) time.Time {
 			if err != nil {
 				log.Warningf("Error while parsing caldav time %s to TimeStamp: %s at location %s", tstring, loc, err)
 			} else {
-				t = t.In(config.GetTimeZone())
-				return t
+				return t.In(config.GetTimeZone())
 			}
 		}
 	}
@@ -475,5 +485,5 @@ func caldavTimeToTimestamp(ianaProperty ics.IANAProperty) time.Time {
 		log.Warningf("Error while parsing caldav time %s to TimeStamp: %s", tstring, err)
 		return time.Time{}
 	}
-	return t
+	return t.In(config.GetTimeZone())
 }

--- a/pkg/caldav/time_parse_test.go
+++ b/pkg/caldav/time_parse_test.go
@@ -1,0 +1,36 @@
+package caldav
+
+import (
+	"testing"
+	"time"
+
+	"code.vikunja.io/api/pkg/config"
+	ics "github.com/arran4/golang-ical"
+)
+
+func Test_caldavTimeToTimestamp_RFC3339(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		expected time.Time
+	}{
+		{
+			name:     "RFC3339",
+			value:    "2024-05-01T12:34:56Z",
+			expected: time.Date(2024, 5, 1, 12, 34, 56, 0, time.UTC).In(config.GetTimeZone()),
+		},
+		{
+			name:     "RFC3339Nano",
+			value:    "2024-05-01T12:34:56.123456789Z",
+			expected: time.Date(2024, 5, 1, 12, 34, 56, 123456789, time.UTC).In(config.GetTimeZone()),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := caldavTimeToTimestamp(ics.IANAProperty{BaseProperty: ics.BaseProperty{Value: tt.value, ICalParameters: map[string][]string{}}})
+			if !got.Equal(tt.expected) {
+				t.Errorf("caldavTimeToTimestamp() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- allow parsing RFC3339 and RFC3339Nano timestamps in `caldavTimeToTimestamp`
- always convert parsed times to Vikunja's configured time zone
- add unit tests for RFC3339 parsing

## Testing
- `mage test:unit`
- `mage test:integration`


------
https://chatgpt.com/codex/tasks/task_e_68452d7f72c88320a0fcb48687dad2b9