### PR TITLE
dynamic flatpickr locale loading

### DIFF
--- a/frontend/src/helpers/useFlatpickrLanguage.ts
+++ b/frontend/src/helpers/useFlatpickrLanguage.ts
@@ -1,22 +1,37 @@
 import {useAuthStore} from '@/stores/auth'
-// TODO: only import needed languages
-import FlatpickrLanguages from 'flatpickr/dist/l10n'
-import type { key } from 'flatpickr/dist/types/locale'
-import { computed } from 'vue'
+import type {key, Locale} from 'flatpickr/dist/types/locale'
+import {computed, ref, watchEffect} from 'vue'
+
+const localeCache: Record<string, Promise<Locale>> = {}
+
+async function loadLocale(code: string): Promise<Locale> {
+	 if (!localeCache[code]) {
+		  if (code === 'en') {
+			localeCache[code] = import('flatpickr/dist/esm/l10n/default.js').then(m => m.default as Locale)
+		  } else {
+			localeCache[code] = import(/* @vite-ignore */ `flatpickr/dist/esm/l10n/${code}.js`)
+			        .then(m => (m.default as Record<key, Locale>)[code as key])
+			        .catch(() => loadLocale('en'))
+		  }
+	 }
+	 return localeCache[code]
+}
 
 export function useFlatpickrLanguage() {
-	const authStore = useAuthStore()
+	 const authStore = useAuthStore()
+	 const locale = ref<Locale>()
+	 loadLocale('en').then(l => (locale.value = l))
 
-	return computed(() => {
-		const userLanguage = authStore.settings.language
-		if (!userLanguage) {
-			return FlatpickrLanguages.en
-		}
+	 watchEffect(async () => {
+		  const userLanguage = authStore.settings.language
+		  const langPair = userLanguage?.split('-') || []
+		  const code = userLanguage === 'vi-VN' ? 'vn' : (langPair[0] || 'en')
 
-		const langPair = userLanguage.split('-')
-		const code = userLanguage === 'vi-VN' ? 'vn' : 'en'
-		const language = FlatpickrLanguages?.[langPair?.[0] as key] || FlatpickrLanguages[code]
-		language.firstDayOfWeek = authStore.settings.weekStart ?? language.firstDayOfWeek
-		return language
-	})
+		  locale.value = await loadLocale(code)
+		  if (authStore.settings.weekStart !== undefined) {
+			locale.value.firstDayOfWeek = authStore.settings.weekStart
+		  }
+	 })
+
+	 return computed(() => locale.value)
 }


### PR DESCRIPTION
## Summary
- dynamically import flatpickr locales based on language
- load english locale by default and update when settings change

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Cannot find name 'ImportMetaEnv')*
- `pnpm test:unit -- --run` *(tests run but process canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68452c2bf5e8832098d4e7f9f7e2cd94