### PR TITLE
fix modelFactory to use entry_type

### DIFF
--- a/frontend/src/services/taskCollection.ts
+++ b/frontend/src/services/taskCollection.ts
@@ -44,11 +44,11 @@ export default class TaskCollectionService extends AbstractService<ITask> {
 		return super.getReplacedRoute(path, pathparams)
 	}
 
-	modelFactory(data) {
-		// FIXME: There must be a better way for this…
-		if (typeof data.project_view_id !== 'undefined') {
-			return new BucketModel(data)
-		}
-		return new TaskModel(data)
-	}
+       modelFactory(data) {
+               // The api marks buckets explicitly via the `entry_type` property.
+               if (data.entryType === 'bucket') {
+                       return new BucketModel(data)
+               }
+               return new TaskModel(data)
+       }
 }


### PR DESCRIPTION
## Summary
- switch taskCollection modelFactory to use `entry_type` instead of `project_view_id`

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Argument of type '{}' is not assignable to parameter of type 'ICaldavToken')*
- `pnpm test:unit`
- `mage test:unit` *(fails: signal interrupt)*
- `mage test:integration` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68452ca85e8c8320bb75012035c6b0b1