### PR TITLE
Fix ratelimit.store default mismatch

### DIFF
--- a/config-raw.json
+++ b/config-raw.json
@@ -459,7 +459,7 @@
                 },
                 {
                     "key": "store",
-                    "default_value": "keyvalue",
+                    "default_value": "memory",
                     "comment": "The store where the limit counter for each user is stored.\nPossible values are \"keyvalue\", \"memory\" or \"redis\".\nWhen choosing \"keyvalue\" this setting follows the one configured in the \"keyvalue\" section."
                 },
                 {


### PR DESCRIPTION
## Summary
- change `ratelimit.store` default in `config-raw.json` to `memory`

## Testing
- `timeout 30 mage test:unit`
- `timeout 30 mage test:integration`


------
https://chatgpt.com/codex/tasks/task_e_68452f668f088320b608283200921087