### PR TITLE
Fix sortable event typing

### DIFF
--- a/frontend/src/components/project/views/ProjectKanban.vue
+++ b/frontend/src/components/project/views/ProjectKanban.vue
@@ -301,6 +301,11 @@ import {
 	saveCollapsedBucketState,
 } from '@/helpers/saveCollapsedBucketState'
 import {calculateItemPosition} from '@/helpers/calculateItemPosition'
+import type { SortableEvent } from 'sortablejs'
+
+interface KanbanSortableEvent extends SortableEvent {
+       newIndex: number
+}
 
 import {isSavedFilter} from '@/services/savedFilter'
 import {success} from '@/message'
@@ -663,8 +668,7 @@ function updateBuckets(value: IBucket[]) {
 	kanbanStore.setBuckets(value)
 }
 
-// TODO: fix type
-function updateBucketPosition(e: { newIndex: number }) {
+function updateBucketPosition(e: KanbanSortableEvent) {
 	// (2) bucket positon is changed
 	dragBucket.value = false
 


### PR DESCRIPTION
## Summary
- define `KanbanSortableEvent` to wrap the drag library event
- use the new type for `updateBucketPosition`

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Argument of type '{}' is not assignable to parameter of type 'ICaldavToken', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68453d51ef9883209cb0e1c36e98783c