### PR TITLE
Fix Kanban label styles

### DIFF
--- a/frontend/src/components/tasks/partials/KanbanCard.vue
+++ b/frontend/src/components/tasks/partials/KanbanCard.vue
@@ -293,10 +293,6 @@ $task-background: var(--white);
 			}
 		}
 
-		// FIXME: should be in Labels.vue
-		:deep(.tag) {
-			margin-left: 0;
-		}
 
 		.priority-label {
 			font-size: .75rem;

--- a/frontend/src/components/tasks/partials/Labels.vue
+++ b/frontend/src/components/tasks/partials/Labels.vue
@@ -26,11 +26,12 @@ const displayLabels = computed(() =>
 
 <style lang="scss" scoped>
 .label-wrapper {
-	display: inline;
-	
-	:deep(.tag) {
-		margin-top: .125rem;
-		margin-bottom: .125rem;
-	}
+        display: inline;
+
+        :deep(.tag) {
+                margin-top: .125rem;
+                margin-bottom: .125rem;
+                margin-left: 0;
+        }
 }
 </style>


### PR DESCRIPTION
## Summary
- move :deep(.tag) styling from KanbanCard to Labels component
- keep Kanban layout intact after style refactor

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: TypeScript errors)*
- `pnpm test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6845401588ac8320a101289b79c41c52