### PR TITLE
docs: update config raw

### DIFF
--- a/config-raw.json
+++ b/config-raw.json
@@ -237,6 +237,11 @@
                     "key": "tls",
                     "default_value": "false",
                     "comment": "Enable SSL/TLS for mysql connections. Options: false, true, skip-verify, preferred"
+                },
+                {
+                    "key": "schema",
+                    "default_value": "public",
+                    "comment": "Schema to use when connecting to PostgreSQL."
                 }
             ]
         },
@@ -295,12 +300,8 @@
                 },
                 {
                     "key": "origins",
-                    "comment": "A list of origins which may access the api. These need to include the protocol (`http://` or `https://`) and port, if any.",
-                    "children": [
-                        {
-                            "default_value": "*"
-                        }
-                    ]
+                    "default_value": ["*"],
+                    "comment": "A list of origins which may access the api. These need to include the protocol (`http://` or `https://`) and port, if any."
                 },
                 {
                     "key": "maxage",
@@ -665,6 +666,7 @@
                         },
                         {
                             "key": "providers",
+                            "default_value": {},
                             "comment": "A list of enabled providers. You can freely choose the `<provider key>`. Note that you must add at least one key to a config file if you want to read values from an environment variable as the provider won't be known to Vikunja otherwise.",
                             "children": [
                                 {


### PR DESCRIPTION
## Summary
- align config-raw.json with current configuration options
- add postgres schema field
- simplify CORS origins default
- provide default for OpenID providers

## Testing
- `mage lint`
- `mage build`
- `mage test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68453be0a4b483209093f4a1bd307782