### PR TITLE
Switch labels store to Map

### DIFF
--- a/frontend/src/stores/labels.ts
+++ b/frontend/src/stores/labels.ts
@@ -22,10 +22,10 @@ async function getAllLabels(page = 1): Promise<ILabel[]> {
 }
 
 export const useLabelStore = defineStore('label', () => {
-	const labels = ref<{ [id: ILabel['id']]: ILabel }>({})
+       const labels = ref<Map<ILabel['id'], ILabel>>(new Map())
 
 	// Alphabetically sort the labels
-	const labelsArray = computed(() => Object.values(labels.value)
+       const labelsArray = computed(() => Array.from(labels.value.values())
 		.sort((a, b) => a.title.localeCompare(
 			b.title, i18n.global.locale.value,
 			{ ignorePunctuation: true },
@@ -35,11 +35,11 @@ export const useLabelStore = defineStore('label', () => {
 	const isLoading = ref(false)
 	
 	const getLabelById = computed(() => {
-		return (labelId: ILabel['id']) => labels.value[labelId]
+               return (labelId: ILabel['id']) => labels.value.get(labelId)
 	})
 
-	const getLabelsByIds = computed(() => (ids: ILabel['id'][]) =>
-		ids.map(id => labels.value[id]).filter(Boolean),
+       const getLabelsByIds = computed(() => (ids: ILabel['id'][]) =>
+               ids.map(id => labels.value.get(id)).filter(Boolean),
 	)
 
 
@@ -50,10 +50,10 @@ export const useLabelStore = defineStore('label', () => {
 		return (labelsToHide: ILabel[], query: string) => {
 			const labelIdsToHide: number[] = labelsToHide.map(({id}) => id)
 
-			return search(query)
-					?.filter(value => !labelIdsToHide.includes(value))
-					.map(id => labels.value[id])
-				|| []
+                       return search(query)
+                                       ?.filter(value => !labelIdsToHide.includes(value))
+                                       .map(id => labels.value.get(id))
+                               || []
 		}
 	})
 
@@ -72,22 +72,22 @@ export const useLabelStore = defineStore('label', () => {
 		isLoading.value = newIsLoading
 	}
 
-	function setLabels(newLabels: ILabel[]) {
-		newLabels.forEach(l => {
-			labels.value[l.id] = l
-			add(l)
-		})
-	}
+       function setLabels(newLabels: ILabel[]) {
+               newLabels.forEach(l => {
+                       labels.value.set(l.id, l)
+                       add(l)
+               })
+       }
 
-	function setLabel(label: ILabel) {
-		labels.value[label.id] = {...label}
-		update(label)
-	}
+       function setLabel(label: ILabel) {
+               labels.value.set(label.id, {...label})
+               update(label)
+       }
 
-	function removeLabelById(label: ILabel) {
-		remove(label)
-		delete labels.value[label.id]
-	}
+       function removeLabelById(label: ILabel) {
+               remove(label)
+               labels.value.delete(label.id)
+       }
 
 	async function loadAllLabels({forceLoad} : {forceLoad?: boolean} = {}) {
 		if (isLoading.value && !forceLoad) {

--- a/frontend/src/stores/tasks.ts
+++ b/frontend/src/stores/tasks.ts
@@ -344,7 +344,7 @@ export const useTaskStore = defineStore('task', () => {
 	async function ensureLabelsExist(labels: string[]): Promise<LabelModel[]> {
 		const all = [...new Set(labels)]
 		const mustCreateLabel = all.map(async labelTitle => {
-			let label = validateLabel(Object.values(labelStore.labels), labelTitle)
+                       let label = validateLabel(Array.from(labelStore.labels.values()), labelTitle)
 			if (typeof label === 'undefined') {
 				// label not found, create it
 				const labelModel = new LabelModel({


### PR DESCRIPTION
## Summary
- refactor labels store to use Map for storage
- update task store accordingly

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: ImportMetaEnv not found)*
- `pnpm test:unit`

------
https://chatgpt.com/codex/tasks/task_e_684544a6e5548320802ae2840d7dced1