### PR TITLE
Fix reaction tooltip slice

### DIFF
--- a/frontend/src/components/input/Reactions.vue
+++ b/frontend/src/components/input/Reactions.vue
@@ -74,11 +74,11 @@ function getReactionTooltip(users: IUser[], value: string) {
 	}
 
 	if (names.length > 1 && names.length < 10) {
-		return t('reaction.reactedWithAnd', {
-			users: names.slice(0, names.length - 1).join(', '),
-			lastUser: names[names.length - 1],
-			value,
-		})
+               return t('reaction.reactedWithAnd', {
+                       users: names.toSpliced(-1, 1).join(', '),
+                       lastUser: names.at(-1),
+                       value,
+               })
 	}
 
 	return t('reaction.reactedWithAndMany', {


### PR DESCRIPTION
## Summary
- modernize array methods in Reactions.vue

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Cannot find name 'ImportMetaEnv', etc.)*
- `pnpm test:unit` *(fails with exit code 130 after cancelling watcher but tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_68454cd2403083208d461bb5871edb36