### PR TITLE
Fix email helper

### DIFF
--- a/frontend/src/helpers/isEmail.ts
+++ b/frontend/src/helpers/isEmail.ts
@@ -1,6 +1,4 @@
 export function isEmail(email: string): boolean {
-	const format = /^.+@.+$/
-	const match = email.match(format)
-
-	return match === null ? false : match.length > 0
+        const format = /^.+@.+$/
+        return format.test(email)
 }


### PR DESCRIPTION
## Summary
- simplify `isEmail` helper using `RegExp.test`

## Testing
- `pnpm --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454cdc37e0832085fc7cdcb0cef6a8