### PR TITLE
Refactor watch dependency list

### DIFF
--- a/frontend/src/components/project/views/ProjectKanban.vue
+++ b/frontend/src/components/project/views/ProjectKanban.vue
@@ -406,22 +406,18 @@ const loading = computed(() => kanbanStore.isLoading)
 const taskLoading = computed(() => taskStore.isLoading || taskPositionService.value.loading)
 
 watch(
-	() => ({
-		params: params.value,
-		projectId: props.projectId,
-		viewId: props.viewId,
-	}),
-	({params, projectId, viewId}) => {
-		if (projectId === undefined || Number(projectId) === 0) {
-			return
-		}
-		collapsedBuckets.value = getCollapsedBucketState(projectId)
-		kanbanStore.loadBucketsForProject(projectId, viewId, params)
-	},
-	{
-		immediate: true,
-		deep: true,
-	},
+       [params, () => props.projectId, () => props.viewId],
+       ([newParams, projectId, viewId]) => {
+               if (projectId === undefined || Number(projectId) === 0) {
+                       return
+               }
+               collapsedBuckets.value = getCollapsedBucketState(projectId)
+               kanbanStore.loadBucketsForProject(projectId, viewId, newParams)
+       },
+       {
+               immediate: true,
+               deep: true,
+       },
 )
 
 function setTaskContainerRef(id: IBucket['id'], el: HTMLElement) {


### PR DESCRIPTION
## Summary
- refactor `ProjectKanban` watcher to monitor params and props individually

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: numerous TS errors)*
- `pnpm test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68454f0619ec8320ac6a64e035e94742