### PR TITLE
Set tab width to four spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,7 @@ root = true
 
 [*]
 indent_style = tab
+tab_width = 4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ These instructions summarize the development guidelines from the official Vikunj
 ## Formatting
 - Respect the formatting rules from `.editorconfig` in the repository root and all subfolders.
 - Adhere to the ESLint rules defined in `frontend/eslint.config.js`. Run `pnpm lint` (or `pnpm lint:fix`) to check and automatically fix issues.
+- Tabs should display as 4 spaces; both `.editorconfig` files set `tab_width = 4`.
 
 ## Testing
 - Set `VIKUNJA_SERVICE_ROOTPATH` to the repository root before running tests so fixtures load correctly.

--- a/frontend/.editorconfig
+++ b/frontend/.editorconfig
@@ -5,6 +5,7 @@ root = true
 
 [*]
 indent_style = tab
+tab_width = 4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary
- define tab width in `.editorconfig` files
- document the convention in `AGENTS.md`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684560d14a508320b4278ea9d8990d32