### PR TITLE
Implement API utilities with tests

### DIFF
--- a/frontend/src/composables/services/index.ts
+++ b/frontend/src/composables/services/index.ts
@@ -1,0 +1,2 @@
+export { default as httpClient } from '@/helpers/httpClient'
+export { useApi } from '../useApi'

--- a/frontend/src/composables/useApi.test.ts
+++ b/frontend/src/composables/useApi.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest'
+import { useApi } from './useApi'
+import httpClient from '@/helpers/httpClient'
+
+describe('useApi', () => {
+	it('toggles loading ref', async () => {
+		vi.useFakeTimers()
+		vi.spyOn(httpClient, 'get').mockResolvedValue({ data: 'ok' })
+		const api = useApi()
+		const promise = api.get('/foo')
+		expect(api.loading.value).toBe(false)
+		vi.advanceTimersByTime(100)
+		expect(api.loading.value).toBe(true)
+		await promise
+		expect(api.loading.value).toBe(false)
+		vi.useRealTimers()
+	})
+
+	it('stores errors in apiError', async () => {
+		vi.spyOn(httpClient, 'get').mockRejectedValue(new Error('fail'))
+		const api = useApi()
+		await expect(api.get('/foo')).rejects.toThrow('fail')
+		expect(api.apiError.value).toBeInstanceOf(Error)
+	})
+})

--- a/frontend/src/composables/useApi.ts
+++ b/frontend/src/composables/useApi.ts
@@ -1,0 +1,44 @@
+import { ref } from 'vue'
+import httpClient from '@/helpers/httpClient'
+
+// Basic helper for direct API calls without using the service classes.
+
+// Delay before marking requests as loading so fast responses don't flicker
+const LOADING_DELAY = 100
+
+export function useApi() {
+	const loading = ref(false)
+	const apiError = ref<unknown>(null)
+
+	function setLoading() {
+		const timeout = setTimeout(() => {
+			loading.value = true
+		}, LOADING_DELAY)
+		return () => {
+			clearTimeout(timeout)
+			loading.value = false
+		}
+	}
+
+	async function request<T>(method: 'get' | 'post' | 'put' | 'delete', ...args: unknown[]): Promise<T> {
+		const cancel = setLoading()
+		try {
+			const { data } = await httpClient[method]<T>(...args as never[])
+			return data
+		} catch (e) {
+			apiError.value = e as unknown
+			throw e
+		} finally {
+			cancel()
+		}
+	}
+
+	return {
+		loading,
+		apiError,
+		get: (url: string, config?: unknown) => request('get', url, config),
+		post: (url: string, data?: unknown, config?: unknown) => request('post', url, data, config),
+		put: (url: string, data?: unknown, config?: unknown) => request('put', url, data, config),
+		delete: (url: string, config?: unknown) => request('delete', url, config),
+	}
+}

--- a/frontend/src/helpers/httpClient.test.ts
+++ b/frontend/src/helpers/httpClient.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect, vi } from 'vitest'
+import httpClient from './httpClient'
+import * as auth from './auth'
+
+describe('httpClient', () => {
+	it('adds auth header and content type', async () => {
+		vi.spyOn(auth, 'getToken').mockReturnValue('token')
+		const config = { headers: {} as Record<string, string>, baseURL: '' }
+		const result = await (httpClient.interceptors.request.handlers[0].fulfilled?.(config) ?? config)
+		expect(result.headers['Authorization']).toBe('Bearer token')
+		expect(result.headers['Content-Type']).toBe('application/json')
+	})
+})

--- a/frontend/src/helpers/httpClient.ts
+++ b/frontend/src/helpers/httpClient.ts
@@ -1,0 +1,34 @@
+import axios from 'axios'
+import type { AxiosInstance } from 'axios'
+import { getToken } from '@/helpers/auth'
+import { error } from '@/message'
+
+// Shared axios instance similar to `AuthenticatedHTTPFactory`.
+// Used by `useApi` when the service classes are overkill.
+
+const httpClient: AxiosInstance = axios.create({
+	baseURL: window.API_URL,
+})
+
+httpClient.interceptors.request.use(config => {
+	config.baseURL = window.API_URL
+	config.headers = {
+	...config.headers,
+	'Content-Type': 'application/json',
+	}
+	const token = getToken()
+	if (token) {
+	config.headers['Authorization'] = `Bearer ${token}`
+	}
+	return config
+})
+
+httpClient.interceptors.response.use(
+	response => response,
+	err => {
+	error(err)
+	return Promise.reject(err)
+	},
+)
+
+export default httpClient


### PR DESCRIPTION
## Summary
- add axios helper singleton with interceptors
- provide `useApi` composable for direct HTTP calls
- export helpers in services index
- cover functionality with unit tests

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Argument of type ...)*
- `CI=1 pnpm test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68459bcfc4748320bdf7e75ea81b6971