### PR TITLE
Fix button import path in histoire setup

### DIFF
--- a/frontend/src/histoire.setup.ts
+++ b/frontend/src/histoire.setup.ts
@@ -9,7 +9,7 @@ import {createPinia} from 'pinia'
 import cypress from '@/directives/cypress'
 
 import FontAwesomeIcon from '@/components/misc/Icon'
-import XButton from '@/components/input/button.vue'
+import XButton from '@/components/input/Button.vue'
 import Modal from '@/components/misc/Modal.vue'
 import Card from '@/components/misc/Card.vue'
 


### PR DESCRIPTION
## Summary
- correct the casing of `Button.vue` import in `histoire.setup.ts`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68465befca00832085a907b508be0761