### PR TITLE
Fix label filter parsing

### DIFF
--- a/pkg/models/task_collection.go
+++ b/pkg/models/task_collection.go
@@ -92,6 +92,7 @@ func validateTaskField(fieldName string) error {
 	case
 		taskPropertyAssignees,
 		taskPropertyLabels,
+		"label",
 		taskPropertyReminders:
 		return nil
 	}

--- a/pkg/models/task_collection_filter.go
+++ b/pkg/models/task_collection_filter.go
@@ -332,6 +332,10 @@ func getNativeValueForTaskField(fieldName string, comparator taskFilterComparato
 
 	realFieldName := strings.ReplaceAll(strcase.ToCamel(fieldName), "Id", "ID")
 
+	if realFieldName == "Label" {
+		realFieldName = "Labels"
+	}
+
 	if realFieldName == "Assignees" {
 		vals := strings.Split(value, ",")
 		valueSlice := append([]string{}, vals...)

--- a/pkg/models/task_collection_filter_test.go
+++ b/pkg/models/task_collection_filter_test.go
@@ -284,4 +284,14 @@ func TestParseFilter(t *testing.T) {
 			assert.Equal(t, 0, date.Year())
 		}
 	})
+
+	t.Run("label filter equals", func(t *testing.T) {
+		result, err := getTaskFiltersFromFilterString("label = 1", "UTC")
+
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, "label", result[0].field)
+		assert.Equal(t, taskFilterComparatorEquals, result[0].comparator)
+		assert.Equal(t, int64(1), result[0].value)
+	})
 }

--- a/pkg/models/task_search.go
+++ b/pkg/models/task_search.go
@@ -44,6 +44,12 @@ type SubTableFilter struct {
 type SubTableFilters map[string]SubTableFilter
 
 var subTableFilters = SubTableFilters{
+	"label": {
+		Table:           "label_tasks",
+		BaseFilter:      "tasks.id = task_id",
+		FilterableField: "label_id",
+		AllowNullCheck:  true,
+	},
 	"labels": {
 		Table:           "label_tasks",
 		BaseFilter:      "tasks.id = task_id",
@@ -498,7 +504,7 @@ func convertParsedFilterToTypesense(rawFilters []*taskFilter) (filterBy string, 
 			f.field = "assignees.username"
 		}
 
-		if f.field == "labels" || f.field == "label_id" {
+		if f.field == "labels" || f.field == "label_id" || f.field == "label" {
 			f.field = "labels.id"
 		}
 


### PR DESCRIPTION
## Summary
- allow `label` as filter for tasks
- update search logic for alias
- convert label field name for reflection
- test label filter parsing

## Testing
- `go test ./pkg/models -run TestParseFilter -count=1`
- `mage test:unit` *(fails: signal interrupt)*
- `mage test:integration` *(fails: exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_68465de649408320920d8b54d4a55f77