### PR TITLE
Fix empty editor html values

### DIFF
--- a/frontend/src/components/input/editor/TipTap.vue
+++ b/frontend/src/components/input/editor/TipTap.vue
@@ -179,7 +179,7 @@ import AttachmentService from '@/services/attachment'
 import BaseButton from '@/components/base/BaseButton.vue'
 import XButton from '@/components/input/Button.vue'
 
-import {isEditorContentEmpty} from '@/helpers/editorContentEmpty'
+import {isEditorContentEmpty, normalizeEditorContent} from '@/helpers/editorContentEmpty'
 import inputPrompt from '@/helpers/inputPrompt'
 import {setLinkInEditor} from '@/components/input/editor/setLinkInEditor'
 
@@ -519,13 +519,15 @@ watch(
 )
 
 function bubbleNow() {
-	if (editor.value?.getHTML() === props.modelValue ||
-		(editor.value?.getHTML() === '<p></p>') && props.modelValue === '') {
-		return
-	}
+       const html = editor.value?.getHTML() || ''
+       const normalized = normalizeEditorContent(html)
 
-	contentHasChanged.value = true
-	emit('update:modelValue', editor.value?.getHTML())
+       if (normalized === props.modelValue) {
+               return
+       }
+
+       contentHasChanged.value = true
+       emit('update:modelValue', normalized)
 }
 
 function bubbleSave() {
@@ -643,8 +645,9 @@ onBeforeUnmount(() => {
 })
 
 function setModeAndValue(value: string) {
-	internalMode.value = isEditorContentEmpty(value) ? 'edit' : 'preview'
-	editor.value?.commands.setContent(value, false)
+       const normalized = normalizeEditorContent(value)
+       internalMode.value = isEditorContentEmpty(normalized) ? 'edit' : 'preview'
+       editor.value?.commands.setContent(normalized, false)
 }
 
 

--- a/frontend/src/helpers/editorContentEmpty.test.ts
+++ b/frontend/src/helpers/editorContentEmpty.test.ts
@@ -1,0 +1,15 @@
+import {describe, expect, it} from 'vitest'
+import {normalizeEditorContent, isEditorContentEmpty} from './editorContentEmpty'
+
+describe('editor content helpers', () => {
+    it('should detect empty html', () => {
+        expect(isEditorContentEmpty('<p></p>')).toBe(true)
+        expect(normalizeEditorContent('<p></p>')).toBe('')
+    })
+
+    it('should keep normal content', () => {
+        const html = '<p>text</p>'
+        expect(isEditorContentEmpty(html)).toBe(false)
+        expect(normalizeEditorContent(html)).toBe(html)
+    })
+})

--- a/frontend/src/helpers/editorContentEmpty.ts
+++ b/frontend/src/helpers/editorContentEmpty.ts
@@ -1,3 +1,12 @@
+export function normalizeEditorContent(content: string): string {
+       const html = content.trim()
+       if (html === '' || html === '<p></p>' || html === '<p><br></p>') {
+               return ''
+       }
+
+       return content
+}
+
 export function isEditorContentEmpty(content: string): boolean {
-	return content === '' || content === '<p></p>'
+       return normalizeEditorContent(content) === ''
 }

--- a/pkg/migration/20250618120100.go
+++ b/pkg/migration/20250618120100.go
@@ -1,0 +1,43 @@
+// Vikunja is a to-do list application to facilitate your life.
+// Copyright 2018-present Vikunja and contributors. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public Licensee as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public Licensee for more details.
+//
+// You should have received a copy of the GNU Affero General Public Licensee
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package migration
+
+import (
+	"src.techknowlogick.com/xormigrate"
+	"xorm.io/xorm"
+)
+
+func removeEmptyDescriptions(tx *xorm.Engine, table, column string) error {
+	_, err := tx.Table(table).Where(column + " = '<p></p>'").Update(map[string]interface{}{column: ""})
+	return err
+}
+
+func init() {
+	migrations = append(migrations, &xormigrate.Migration{
+		ID:          "20250618120100",
+		Description: "Remove empty editor html",
+		Migrate: func(tx *xorm.Engine) error {
+			for _, table := range []string{"tasks", "labels", "projects", "saved_filters", "teams"} {
+				if err := removeEmptyDescriptions(tx, table, "description"); err != nil {
+					return err
+				}
+			}
+			return removeEmptyDescriptions(tx, "task_comments", "comment")
+		},
+		Rollback: func(tx *xorm.Engine) error { return nil },
+	})
+}


### PR DESCRIPTION
## Summary
- handle editor empty string normalization
- emit empty string instead of `<p></p>` from the editor
- update task editor logic
- add migration to strip stored `<p></p>` values
- test helper for empty editor content

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: TS errors)*
- `pnpm test:unit`
- `mage -v test:integration` *(partial output)*

------
https://chatgpt.com/codex/tasks/task_e_68465e066d5c8320bb280b0859233e66