### PR TITLE
Fix BaseButton import in DropdownItem

### DIFF
--- a/frontend/src/components/misc/DropdownItem.vue
+++ b/frontend/src/components/misc/DropdownItem.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script lang="ts" setup>
-import BaseButton, {type BaseButtonProps} from '@/components/base//BaseButton.vue'
+import BaseButton, {type BaseButtonProps} from '@/components/base/BaseButton.vue'
 import Icon from '@/components/misc/Icon'
 import type {IconProp} from '@fortawesome/fontawesome-svg-core'
 


### PR DESCRIPTION
## Summary
- correct the path for BaseButton in `DropdownItem.vue`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68465e8a94d483208d5f6604650d5447