### PR TITLE
Fix trello org board auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ try it on [try.vikunja.io](https://try.vikunja.io)!
 
 All docs can be found on [the Vikunja home page](https://vikunja.io/docs/).
 
+### Trello Migration Authentication
+
+When migrating from Trello make sure the generated token includes the
+`account` scope so Vikunja can access boards that belong to organizations.
+Unauthorized boards will be skipped with an error if the token does not have
+this scope.
+
 ### Roadmap
 
 See [the roadmap](https://my.vikunja.cloud/share/QFyzYEmEYfSyQfTOmIRSwLUpkFjboaBqQCnaPmWd/auth) (hosted on Vikunja!) for more!


### PR DESCRIPTION
## Summary
- extend trello auth scope to include organizations
- get board organization ids when fetching boards
- add clearer errors when a board or organization can't be accessed
- document Trello auth requirements

## Testing
- `mage lint`
- `mage test:unit` *(fails: signal interrupt)*
- `mage test:integration` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_684664c2d6e08320ae72c4ef7f72c50d