### PR TITLE
Fix focus styles using :focus-visible

### DIFF
--- a/frontend/src/components/home/ContentAuth.vue
+++ b/frontend/src/components/home/ContentAuth.vue
@@ -149,10 +149,17 @@ projectStore.loadAllProjects()
 		display: none;
 	}
 
-	&:hover,
-	&:focus {
-		color: var(--grey-600);
-	}
+       &:hover,
+       &:focus-visible {
+               color: var(--grey-600);
+       }
+
+       @supports not selector(:focus-visible) {
+               &:hover,
+               &:focus {
+                       color: var(--grey-600);
+               }
+       }
 }
 
 .app-container {

--- a/frontend/src/components/home/MenuButton.vue
+++ b/frontend/src/components/home/MenuButton.vue
@@ -55,16 +55,34 @@ $size: $lineWidth + 1rem;
 		transform: $transformX translateY(0.4rem)
 	}
 
-	&:hover,
-	&:focus {
-		&::before,
-		&::after {
-			background-color: var(--grey-600);
-		}
+       &:hover,
+       &:focus-visible {
+               &::before,
+               &::after {
+                       background-color: var(--grey-600);
+               }
 
 		&::before {
 			transform: $transformX translateY(-0.5rem);
-		}
+       }
+
+       @supports not selector(:focus-visible) {
+               &:hover,
+               &:focus {
+                       &::before,
+                       &::after {
+                               background-color: var(--grey-600);
+                       }
+
+                       &::before {
+                               transform: $transformX translateY(-0.5rem);
+                       }
+
+                       &::after {
+                               transform: $transformX translateY(0.5rem)
+                       }
+               }
+       }
 
 		&::after {
 			transform: $transformX translateY(0.5rem)

--- a/frontend/src/components/input/AutocompleteDropdown.vue
+++ b/frontend/src/components/input/AutocompleteDropdown.vue
@@ -217,11 +217,19 @@ function onUpdateField(e) {
 			border: none;
 			cursor: pointer;
 
-			&:focus,
-			&:hover {
-				background: var(--grey-100);
-				box-shadow: none !important;
-			}
+                       &:focus-visible,
+                       &:hover {
+                               background: var(--grey-100);
+                               box-shadow: none !important;
+                       }
+
+                       @supports not selector(:focus-visible) {
+                               &:focus,
+                               &:hover {
+                                       background: var(--grey-100);
+                                       box-shadow: none !important;
+                               }
+                       }
 
 			&:active {
 				background: var(--grey-100);

--- a/frontend/src/components/input/Button.vue
+++ b/frontend/src/components/input/Button.vue
@@ -94,13 +94,23 @@ const variantClass = computed(() => VARIANT_CLASS_MAP[props.variant])
 		height: 100%;
 	}
 
-	&.is-active,
-	&.is-focused,
-	&:active,
-	&:focus,
-	&:focus:not(:active) {
-		box-shadow: var(--shadow-xs) !important;
-	}
+       &.is-active,
+       &.is-focused,
+       &:active,
+       &:focus-visible,
+       &:focus-visible:not(:active) {
+               box-shadow: var(--shadow-xs) !important;
+       }
+
+       @supports not selector(:focus-visible) {
+               &.is-active,
+               &.is-focused,
+               &:active,
+               &:focus,
+               &:focus:not(:active) {
+                       box-shadow: var(--shadow-xs) !important;
+               }
+       }
 
 	&.is-primary.is-outlined:hover {
 		color: var(--white);

--- a/frontend/src/components/input/Multiselect.vue
+++ b/frontend/src/components/input/Multiselect.vue
@@ -550,14 +550,26 @@ function focus() {
 	align-items: center;
 	overflow: hidden;
 
-	&:focus,
-	&:hover {
-		background: var(--grey-100);
-		box-shadow: none !important;
+       &:focus-visible,
+       &:hover {
+               background: var(--grey-100);
+               box-shadow: none !important;
 
 		.hint-text {
 			color: var(--text);
-		}
+       }
+
+       @supports not selector(:focus-visible) {
+               &:focus,
+               &:hover {
+                       background: var(--grey-100);
+                       box-shadow: none !important;
+
+                       .hint-text {
+                               color: var(--text);
+                       }
+               }
+       }
 	}
 
 	&:active {

--- a/frontend/src/components/project/partials/ProjectCard.vue
+++ b/frontend/src/components/project/partials/ProjectCard.vue
@@ -94,10 +94,17 @@ const textOnlyDescription = computed(() => {
 		box-shadow: var(--shadow-md);
 	}
 
-	&:active,
-	&:focus {
-		box-shadow: var(--shadow-xs) !important;
-	}
+       &:active,
+       &:focus-visible {
+               box-shadow: var(--shadow-xs) !important;
+       }
+
+       @supports not selector(:focus-visible) {
+               &:active,
+               &:focus {
+                       box-shadow: var(--shadow-xs) !important;
+               }
+       }
 
 	> * {
 		// so the elements are on top of the background

--- a/frontend/src/components/quick-actions/QuickActions.vue
+++ b/frontend/src/components/quick-actions/QuickActions.vue
@@ -662,11 +662,19 @@ function reset() {
 	border: none;
 	cursor: pointer;
 
-	&:focus,
-	&:hover {
-		background: var(--grey-100);
-		box-shadow: none !important;
-	}
+       &:focus-visible,
+       &:hover {
+               background: var(--grey-100);
+               box-shadow: none !important;
+       }
+
+       @supports not selector(:focus-visible) {
+               &:focus,
+               &:hover {
+                       background: var(--grey-100);
+                       box-shadow: none !important;
+               }
+       }
 
 	&:active {
 		background: var(--grey-100);

--- a/frontend/src/components/tasks/partials/SingleTaskInProject.vue
+++ b/frontend/src/components/tasks/partials/SingleTaskInProject.vue
@@ -491,9 +491,15 @@ function openTaskDetail(event: MouseEvent | KeyboardEvent) {
 		}
 	}
 
-	.favorite:focus {
-		opacity: 1;
-	}
+       .favorite:focus-visible {
+               opacity: 1;
+       }
+
+       @supports not selector(:focus-visible) {
+               .favorite:focus {
+                       opacity: 1;
+               }
+       }
 
 	:deep(.fancy-checkbox) {
 		height: 18px;

--- a/frontend/src/views/tasks/TaskDetailView.vue
+++ b/frontend/src/views/tasks/TaskDetailView.vue
@@ -1090,13 +1090,23 @@ h3 .button {
 		}
 
 		&:not(:disabled) {
-			&:hover,
-			&:active,
-			&:focus {
-				background: var(--scheme-main);
-				border-color: var(--border);
-				cursor: text;
-			}
+                       &:hover,
+                       &:active,
+                       &:focus-visible {
+                               background: var(--scheme-main);
+                               border-color: var(--border);
+                               cursor: text;
+                       }
+
+                       @supports not selector(:focus-visible) {
+                               &:hover,
+                               &:active,
+                               &:focus {
+                                       background: var(--scheme-main);
+                                       border-color: var(--border);
+                                       cursor: text;
+                               }
+                       }
 
 			&:hover,
 			&:active {


### PR DESCRIPTION
## Summary
- rely on `:focus-visible` for better focus outlines
- keep fallback styling for browsers without `:focus-visible`

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Cannot find name 'ImportMetaEnv', etc.)*
- `CI=1 pnpm test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68468c03348083209bae67c1149cf746