### PR TITLE
Add aria-label to QuickActions input

### DIFF
--- a/frontend/src/components/quick-actions/QuickActions.vue
+++ b/frontend/src/components/quick-actions/QuickActions.vue
@@ -15,17 +15,18 @@
 				>
 					{{ selectedCmd.title }}
 				</div>
-				<input
-					ref="searchInput"
-					v-model="query"
-					v-focus
-					class="input"
-					:class="{'is-loading': loading}"
-					:placeholder="placeholder"
-					@keyup="search"
-					@keydown.down.prevent="select(0, 0)"
-					@keyup.prevent.delete="unselectCmd"
-					@keyup.prevent.enter="doCmd"
+<input
+ref="searchInput"
+v-model="query"
+v-focus
+class="input"
+:class="{'is-loading': loading}"
+:placeholder="placeholder"
+:aria-label="$t('quickActions.searchAriaLabel')"
+@keyup="search"
+@keydown.down.prevent="select(0, 0)"
+@keyup.prevent.delete="unselectCmd"
+@keyup.prevent.enter="doCmd"
 					@keyup.prevent.esc="closeQuickActions"
 				>
 				<BaseButton

--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -1117,6 +1117,7 @@
   "quickActions": {
     "commands": "Commands",
     "placeholder": "Type a command or search…",
+    "searchAriaLabel": "Quick actions search",
     "hint": "You can use {project} to limit the search to a project. Combine {project} or {label} (labels) with a search query to search for a task with these labels or on that project. Use {assignee} to only search for teams.",
     "tasks": "Tasks",
     "projects": "Projects",


### PR DESCRIPTION
## Summary
- improve accessibility by localizing the quick actions search aria label

## Testing
- `pnpm lint` *(fails: command not found)*
- `pnpm typecheck` *(fails: command not found)*
- `pnpm test:unit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68468de2b17c8320a80537ab7158074c