### PR TITLE
Set color-scheme for themes

### DIFF
--- a/frontend/src/styles/custom-properties/colors.scss
+++ b/frontend/src/styles/custom-properties/colors.scss
@@ -264,6 +264,7 @@
   --code-keyword: #8338ec;
 
   &.dark {
+    color-scheme: dark;
     @media screen {
       // Light mode colours reversed for dark mode
       --grey-900-hsl: 210, 20%, 98%;

--- a/frontend/src/styles/theme/theme.scss
+++ b/frontend/src/styles/theme/theme.scss
@@ -20,6 +20,7 @@ a, button {
 :root {
   // Bulma sets this to "scroll" which gives us a scrollbar even if there's no content to scroll
   --body-overflow-y: auto;
+  color-scheme: light dark;
 }
 
 // The LanguageTool browser plugin creates a custom element with shadow root for textareas.


### PR DESCRIPTION
## Summary
- expose preferred color schemes in :root
- set `color-scheme: dark` for the `.dark` theme

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Argument of type errors)*
- `pnpm test:unit --run`

------
https://chatgpt.com/codex/tasks/task_e_68468eb14d54832085da57f93932d682