### PR TITLE
Drop unused Bulma imports

### DIFF
--- a/frontend/src/styles/global.scss
+++ b/frontend/src/styles/global.scss
@@ -23,11 +23,11 @@
 // imports from "bulma-css-variables/sass/elements/_all";
 @import "bulma-css-variables/sass/elements/box";
 @import "bulma-css-variables/sass/elements/button";
-@import "bulma-css-variables/sass/elements/container";
+// @import "bulma-css-variables/sass/elements/container"; // not used
 @import "bulma-css-variables/sass/elements/content";
 @import "bulma-css-variables/sass/elements/icon";
 @import "bulma-css-variables/sass/elements/image";
-//@import "bulma-css-variables/sass/elements/notification"; // not used
+// @import "bulma-css-variables/sass/elements/notification"; // not used
 // @import "bulma-css-variables/sass/elements/progress"; // not used
 @import "bulma-css-variables/sass/elements/table";
 @import "bulma-css-variables/sass/elements/tag";
@@ -41,18 +41,18 @@
 @import "bulma-css-variables/sass/form/input-textarea";
 @import "bulma-css-variables/sass/form/checkbox-radio";
 @import "bulma-css-variables/sass/form/select";
-@import "bulma-css-variables/sass/form/file";
+// @import "bulma-css-variables/sass/form/file"; // not used
 @import "bulma-css-variables/sass/form/tools";
 
 
 // imports from "bulma-css-variables/sass/components/_all";
 // @import "bulma-css-variables/sass/components/breadcrumb"; // not used
 @import "bulma-css-variables/sass/components/card";
-// @import "bulma-css-variables/sass/components/dropdown"; // moved to component
+// @import "bulma-css-variables/sass/components/dropdown"; // not used
 // @import "bulma-css-variables/sass/components/level"; // not used
 @import "bulma-css-variables/sass/components/media"; 
 @import "bulma-css-variables/sass/components/menu";
-//@import "bulma-css-variables/sass/components/message"; // not used
+// @import "bulma-css-variables/sass/components/message"; // not used
 @import "bulma-css-variables/sass/components/modal";
 @import "bulma-css-variables/sass/components/navbar";
 @import "bulma-css-variables/sass/components/pagination";
@@ -70,8 +70,8 @@
 @import "bulma-css-variables/sass/helpers/flexbox";
 @import "bulma-css-variables/sass/helpers/float";
 // @import "bulma-css-variables/sass/helpers/other"; // not used
-// @import "bulma-css-variables/sass/helpers/overflow";
-// @import "bulma-css-variables/sass/helpers/position";
+// @import "bulma-css-variables/sass/helpers/overflow"; // not used
+// @import "bulma-css-variables/sass/helpers/position"; // not used
 @import "bulma-css-variables/sass/helpers/spacing";
 @import "bulma-css-variables/sass/helpers/typography";
 @import "bulma-css-variables/sass/helpers/visibility";


### PR DESCRIPTION
## Summary
- remove unused Bulma imports in global styles
- rebuild frontend bundle to verify size
- lint frontend

## Testing
- `pnpm lint`
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_684692dd6ff0832080d104f58beadcab