### PR TITLE
Dynamic flatpickr locale loading

### DIFF
--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -5,7 +5,7 @@ import langEN from './lang/en.json'
 import localizedFormat from 'dayjs/plugin/localizedFormat'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import dayjs from 'dayjs'
-import {loadDayJsLocale} from '@/i18n/useDayjsLanguageSync.ts'
+import {loadDayjsLocale} from '@/i18n/localeMappings'
 
 dayjs.extend(localizedFormat)
 dayjs.extend(relativeTime)
@@ -38,8 +38,8 @@ export const SUPPORTED_LOCALES = {
 	'ko-KR': '한국어',
 	'tr-TR': 'Türkçe',
 	'fi-FI': 'Suomi',
-	'he-IL': 'עִבְרִית',
-	// IMPORTANT: Also add new languages to useDayjsLanguageSync
+       'he-IL': 'עִבְרִית',
+       // IMPORTANT: Also add new languages to localeMappings.ts
 	// IMPORTANT: Also add new languages to pkg/i18n/i18n.go
 } as const
 
@@ -98,7 +98,7 @@ export async function setLanguage(lang: SupportedLocale): Promise<SupportedLocal
 		}
 	}
 	
-	await loadDayJsLocale(lang)
+       await loadDayjsLocale(lang)
 
 	i18n.global.locale.value = lang
 	document.documentElement.lang = lang

--- a/frontend/src/i18n/localeMappings.ts
+++ b/frontend/src/i18n/localeMappings.ts
@@ -1,0 +1,65 @@
+import type {SupportedLocale} from '@/i18n'
+import english from 'flatpickr/dist/l10n/default.js'
+import type {CustomLocale, key as FlatpickrKey} from 'flatpickr/dist/types/locale'
+
+export const LOCALE_MAPPING = {
+	'de-de': {dayjs: 'de', flatpickr: 'de'},
+	'de-swiss': {dayjs: 'de-ch', flatpickr: 'de'},
+	'ru-ru': {dayjs: 'ru', flatpickr: 'ru'},
+	'fr-fr': {dayjs: 'fr', flatpickr: 'fr'},
+	'vi-vn': {dayjs: 'vi', flatpickr: 'vn'},
+	'it-it': {dayjs: 'it', flatpickr: 'it'},
+	'cs-cz': {dayjs: 'cs', flatpickr: 'cs'},
+	'pl-pl': {dayjs: 'pl', flatpickr: 'pl'},
+	'nl-nl': {dayjs: 'nl', flatpickr: 'nl'},
+	'pt-pt': {dayjs: 'pt', flatpickr: 'pt'},
+	'zh-cn': {dayjs: 'zh-cn', flatpickr: 'zh'},
+	'no-no': {dayjs: 'nb', flatpickr: 'no'},
+	'es-es': {dayjs: 'es', flatpickr: 'es'},
+	'da-dk': {dayjs: 'da', flatpickr: 'da'},
+	'ja-jp': {dayjs: 'ja', flatpickr: 'ja'},
+	'hu-hu': {dayjs: 'hu', flatpickr: 'hu'},
+	'ar-sa': {dayjs: 'ar-sa', flatpickr: 'ar'},
+	'sl-si': {dayjs: 'sl', flatpickr: 'sl'},
+	'pt-br': {dayjs: 'pt-br', flatpickr: 'pt'},
+	'hr-hr': {dayjs: 'hr', flatpickr: 'hr'},
+	'uk-ua': {dayjs: 'uk', flatpickr: 'uk'},
+	'lt-lt': {dayjs: 'lt', flatpickr: 'lt'},
+	'bg-bg': {dayjs: 'bg', flatpickr: 'bg'},
+	'ko-kr': {dayjs: 'ko', flatpickr: 'ko'},
+	'tr-tr': {dayjs: 'tr', flatpickr: 'tr'},
+	'fi-fi': {dayjs: 'fi', flatpickr: 'fi'},
+	'he-il': {dayjs: 'he', flatpickr: 'he'},
+} as const satisfies Partial<Record<SupportedLocale, {dayjs: string; flatpickr: FlatpickrKey}>>
+
+export async function loadFlatpickrLocale(lang: SupportedLocale): Promise<CustomLocale> {
+	if (lang === 'en') {
+	return english.default
+}
+	const entry = LOCALE_MAPPING[lang.toLowerCase() as SupportedLocale]
+	const code = entry?.flatpickr
+	if (!code || code === 'en') {
+	return english.default
+}
+	try {
+const mod: unknown = await import(/* @vite-ignore */ `flatpickr/dist/l10n/${code}.js`)
+// flatpickr's locale modules export the locale inside mod.default.default
+const localeData = (mod as {default?: {default?: Record<string, CustomLocale>}}).default
+return localeData?.default?.[code] || english.default
+} catch (e) {
+	console.error('Failed to load flatpickr locale', e)
+	return english.default
+}
+}
+
+export async function loadDayjsLocale(lang: SupportedLocale): Promise<void> {
+	if (lang === 'en') {
+	return
+}
+	const entry = LOCALE_MAPPING[lang.toLowerCase() as SupportedLocale]
+	const code = entry?.dayjs
+	if (!code || code === 'en') {
+	return
+}
+	await import(/* @vite-ignore */ `dayjs/locale/${code}`)
+}

--- a/frontend/src/i18n/useDayjsLanguageSync.ts
+++ b/frontend/src/i18n/useDayjsLanguageSync.ts
@@ -1,75 +1,10 @@
 import {computed, ref, watch} from 'vue'
 import type dayjs from 'dayjs'
 
-import {i18n, type ISOLanguage, type SupportedLocale} from '@/i18n'
+import {i18n, type SupportedLocale} from '@/i18n'
+import {LOCALE_MAPPING, loadDayjsLocale} from '@/i18n/localeMappings'
 
-export const DAYJS_LOCALE_MAPPING = {
-	'de-de': 'de',
-	'de-swiss': 'de-ch',
-	'ru-ru': 'ru',
-	'fr-fr': 'fr',
-	'vi-vn': 'vi',
-	'it-it': 'it',
-	'cs-cz': 'cs',
-	'pl-pl': 'pl',
-	'nl-nl': 'nl',
-	'pt-pt': 'pt',
-	'zh-cn': 'zh-cn',
-	'no-no': 'nb',
-	'es-es': 'es',
-	'da-dk': 'da',
-	'ja-jp': 'ja',
-	'hu-hu': 'hu',
-	'ar-sa': 'ar-sa',
-	'sl-si': 'sl',
-	'pt-br': 'pt',
-	'hr-hr': 'hr',
-	'uk-ua': 'uk',
-	'lt-lt': 'lt',
-	'bg-bg': 'bg',
-	'ko-kr': 'ko',
-	'tr-tr': 'tr',
-	'fi-fi': 'fi',
-	'he-il': 'he',
-} as Record<SupportedLocale, ISOLanguage>
-
-export const DAYJS_LANGUAGE_IMPORTS = {
-	'de-de': () => import('dayjs/locale/de'),
-	'de-swiss': () => import('dayjs/locale/de-ch'),
-	'ru-ru': () => import('dayjs/locale/ru'),
-	'fr-fr': () => import('dayjs/locale/fr'),
-	'vi-vn': () => import('dayjs/locale/vi'),
-	'it-it': () => import('dayjs/locale/it'),
-	'cs-cz': () => import('dayjs/locale/cs'),
-	'pl-pl': () => import('dayjs/locale/pl'),
-	'nl-nl': () => import('dayjs/locale/nl'),
-	'pt-pt': () => import('dayjs/locale/pt'),
-	'zh-cn': () => import('dayjs/locale/zh-cn'),
-	'no-no': () => import('dayjs/locale/nb'),
-	'es-es': () => import('dayjs/locale/es'),
-	'da-dk': () => import('dayjs/locale/da'),
-	'ja-jp': () => import('dayjs/locale/ja'),
-	'hu-hu': () => import('dayjs/locale/hu'),
-	'ar-sa': () => import('dayjs/locale/ar-sa'),
-	'sl-si': () => import('dayjs/locale/sl'),
-	'pt-br': () => import('dayjs/locale/pt-br'),
-	'hr-hr': () => import('dayjs/locale/hr'),
-	'uk-ua': () => import('dayjs/locale/uk'),
-	'lt-lt': () => import('dayjs/locale/lt'),
-	'bg-bg': () => import('dayjs/locale/bg'),
-	'ko-kr': () => import('dayjs/locale/ko'),
-	'tr-tr': () => import('dayjs/locale/tr'),
-	'fi-fi': () => import('dayjs/locale/fi'),
-	'he-il': () => import('dayjs/locale/he'),
-} as Record<SupportedLocale, () => Promise<ILocale>>
-
-export async function loadDayJsLocale(language: SupportedLocale) {
-	if (language === 'en') {
-		return
-	}
-
-	await DAYJS_LANGUAGE_IMPORTS[language.toLowerCase()]()
-}
+export {loadDayjsLocale}
 
 export function useDayjsLanguageSync(dayjsGlobal: typeof dayjs) {
 
@@ -80,12 +15,13 @@ export function useDayjsLanguageSync(dayjsGlobal: typeof dayjs) {
 			if (!dayjsGlobal) {
 				return
 			}
-			const dayjsLanguageCode = DAYJS_LOCALE_MAPPING[currentLanguage.toLowerCase()] || currentLanguage.toLowerCase()
+			const mappingEntry = LOCALE_MAPPING[currentLanguage.toLowerCase() as SupportedLocale]
+			const dayjsLanguageCode = mappingEntry?.dayjs || currentLanguage.toLowerCase()
 			dayjsLanguageLoaded.value = dayjsGlobal.locale() === dayjsLanguageCode
 			if (dayjsLanguageLoaded.value) {
-				return
+			return
 			}
-			await loadDayJsLocale(currentLanguage)
+						await loadDayjsLocale(currentLanguage as SupportedLocale)
 			dayjsGlobal.locale(dayjsLanguageCode)
 			dayjsLanguageLoaded.value = true
 		},


### PR DESCRIPTION
## Summary
- centralize flatpickr locale mapping and dynamic loader
- use the loader in `useFlatpickrLanguage`
- reuse shared mapping for dayjs language sync

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: many existing errors)*


------
https://chatgpt.com/codex/tasks/task_e_68468edbdbf88320841411a2b3774eb8