### PR TITLE
Fix Modal semantics

### DIFF
--- a/frontend/src/components/misc/Modal.vue
+++ b/frontend/src/components/misc/Modal.vue
@@ -14,6 +14,9 @@
 					variant,
 				]"
 				v-bind="attrs"
+				role="dialog"
+				aria-modal="true"
+				:aria-labelledby="hasHeader ? HEADER_ID : undefined"
 			>
 				<div
 					v-shortcut="'Escape'"
@@ -34,7 +37,10 @@
 						}"
 					>
 						<slot>
-							<div class="modal-header">
+							<div
+								:id="hasHeader ? HEADER_ID : undefined"
+								class="modal-header"
+							>
 								<slot name="header" />
 							</div>
 							<div class="content">
@@ -68,7 +74,7 @@
 <script lang="ts" setup>
 import CustomTransition from '@/components/misc/CustomTransition.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
-import {ref, useAttrs, watchEffect} from 'vue'
+import {ref, useAttrs, useSlots, watchEffect} from 'vue'
 import {useScrollLock} from '@vueuse/core'
 
 const props = withDefaults(defineProps<{
@@ -91,7 +97,11 @@ defineOptions({
 	inheritAttrs: false,
 })
 
+const HEADER_ID = 'modal-header'
+
 const attrs = useAttrs()
+const slots = useSlots()
+const hasHeader = Boolean(slots.header)
 
 const modal = ref<HTMLElement | null>(null)
 const scrollLock = useScrollLock(modal)


### PR DESCRIPTION
## Summary
- add `dialog` role to Modal section
- expose `aria-labelledby` only when a header slot exists

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: exit code 1)*
- `pnpm test:unit` *(fails: exit code 130)*

------
https://chatgpt.com/codex/tasks/task_e_68468e2c9d3c8320bbb410df7f8b3176