### PR TITLE
Use container queries for task width

### DIFF
--- a/frontend/src/styles/components/tasks.scss
+++ b/frontend/src/styles/components/tasks.scss
@@ -2,12 +2,12 @@
 // very hard to untangle
 // they have many overwrites at different positions
 .tasks {
-	text-align: left;
+       text-align: left;
+       container-type: inline-size;
 
-	
-	@media screen and (max-width: $tablet) {
-		max-width: 100%;
-	}
+       @media screen and (max-width: $tablet) {
+               max-width: 100%;
+       }
 
 	&.short {
 		@media screen and (min-width: $tablet) {
@@ -24,20 +24,20 @@
 // - RelatedTasks.vue
 // - SingleTaskInProject.vue
 .is-menu-enabled .tasks .task {
-	span:not(.tag), a {
-		.tasktext,
-		&.tasktext {
-			@media screen and (max-width: $desktop) {
-				max-width: calc(100vw - 27px - 2rem - 1.5rem - 3rem - #{$navbar-width}); // 1.5rem is the padding of the tasks container, 3rem is the padding of .app-container
-			}
+       span:not(.tag), a {
+               .tasktext,
+               &.tasktext {
+                       @container (max-width: $desktop) {
+                               max-width: calc(100cqw - 27px - 2rem - 1.5rem - 3rem - #{$navbar-width}); // 1.5rem is the padding of the tasks container, 3rem is the padding of .app-container
+                       }
 
-			// Duplicated rule to have it work properly in at least some browsers
-			// This should be fine as the ui doesn't work in rare edge cases to begin with
-			@media screen and (max-width: calc(#{$desktop} + #{$navbar-width})) {
-				max-width: calc(100vw - 27px - 2rem - 1.5rem - 3rem - #{$navbar-width}); // 1.5rem is the padding of the tasks container, 3rem is the padding of .app-container
-			}
-		}
-	}
+                       // Duplicated rule to have it work properly in at least some browsers
+                       // This should be fine as the ui doesn't work in rare edge cases to begin with
+                       @container (max-width: calc(#{$desktop} + #{$navbar-width})) {
+                               max-width: calc(100cqw - 27px - 2rem - 1.5rem - 3rem - #{$navbar-width}); // 1.5rem is the padding of the tasks container, 3rem is the padding of .app-container
+                       }
+               }
+       }
 }
 
 // FIXME: is only used where <edit-task> is used aswell:


### PR DESCRIPTION
## Summary
- enable container queries on tasks container
- set `max-width` via `@container` instead of viewport

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Argument of type '{}' is not assignable to parameter of type 'ICaldavToken' ...)*
- `CI=true pnpm test:unit -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68468e964e9c8320af8ba3c3d19e32a5