### PR TITLE
Add visualizer stats to GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,11 @@ jobs:
     needs:
       - test
     secrets: inherit
+
+  visualizer:
+    name: Publish Visualizer Stats
+    if: ${{ github.ref_name == 'main' || github.event_name == 'pull_request' }}
+    uses: ./.github/workflows/visualizer.yml
+    needs:
+      - test
+    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -271,6 +271,11 @@ jobs:
       - name: Build frontend
         working-directory: frontend
         run: pnpm build
+      - name: Store visualizer stats
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: visualizer_stats
+          path: ./frontend/stats.html
       - name: Store Frontend
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/.github/workflows/visualizer.yml
+++ b/.github/workflows/visualizer.yml
@@ -1,0 +1,84 @@
+name: Build Visualizer
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout GitHub Pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: site
+          fetch-depth: 1
+
+      - name: Download stats artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: visualizer_stats
+
+      - name: Store current stats
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          TARGET=site
+          if [ "$REF_NAME" = "main" ]; then
+            DIR="$TARGET/main"
+          else
+            DIR="$TARGET/pr-$PR_NUMBER"
+          fi
+          mkdir -p "$DIR"
+          mv stats.html "$DIR/index.html"
+
+      - name: Remove closed PR stats
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TARGET=site
+          open_prs=$(curl -s -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/pulls?state=open" | jq '.[].number')
+          for dir in $TARGET/pr-*; do
+            [ -d "$dir" ] || continue
+            pr=${dir##*/pr-}
+            if ! echo "$open_prs" | grep -w "$pr" >/dev/null; then
+              rm -rf "$dir"
+            fi
+          done
+
+      - name: Generate index
+        run: |
+          TARGET=site
+          {
+            echo '<html><body><h1>Visualizer Stats</h1><ul>'
+            echo '<li><a href="./main/">main</a></li>'
+            for dir in "$TARGET"/pr-*; do
+              [ -d "$dir" ] || continue
+              pr=${dir##*/pr-}
+              echo "<li><a href=\"./pr-$pr/\">PR #$pr</a></li>"
+            done
+            echo '</ul></body></html>'
+          } > "$TARGET/index.html"
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
## Summary
- store `stats.html` from frontend build as workflow artifact
- keep stats for all open PRs and main branch on GitHub Pages
- generate overview index with links to each stats file
- remove stats for closed PRs automatically

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Argument of type '{}' is not assignable...)*

------
https://chatgpt.com/codex/tasks/task_e_6846a2708eec83209ab7a412b1d44fee