### PR TITLE
Add github release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,11 @@ jobs:
           target-path: /vikunja/${{ github.ref_type == 'tag' && steps.ghd.outputs.describe || 'unstable' }}
           files: 'dist/zip/*'
           strip-path-prefix: dist/zip/
+      - name: Store Release Files
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: release_files
+          path: ./dist/zip/*
       - name: Store Binaries
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -175,6 +180,11 @@ jobs:
           target-path: /vikunja/${{ github.ref_type == 'tag' && steps.ghd.outputs.describe || 'unstable' }}
           files: 'dist/os-packages/*'
           strip-path-prefix: dist/os-packages/
+      - name: Store OS Packages
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: vikunja_pkg_${{ matrix.package }}
+          path: ./dist/os-packages/*.${{ matrix.package }}
 
   config-yaml:
     runs-on: ubuntu-latest
@@ -201,6 +211,11 @@ jobs:
           s3-region: 'fsn1'
           target-path: /vikunja/${{ github.ref_type == 'tag' && steps.ghd.outputs.describe || 'unstable' }}
           files: 'config.yml.sample'
+      - name: Store Config Sample
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: config_yaml_sample
+          path: config.yml.sample
 
   desktop:
     strategy:
@@ -251,6 +266,12 @@ jobs:
           target-path: /desktop/${{ github.ref_type == 'tag' && steps.ghd.outputs.describe || 'unstable' }}
           strip-path-prefix: desktop/dist/
           exclude: 'desktop/dist/*.blockmap'
+      - name: Store Desktop Builds
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: desktop_${{ matrix.os }}
+          path: desktop/dist/Vikunja*
+          if-no-files-found: error
   
   generate-swagger-docs:
     runs-on: ubuntu-latest
@@ -296,3 +317,39 @@ jobs:
         with:
           ssh: true
           branch: ${{ github.ref }}
+  github-release:
+    if: ${{ github.ref_type == 'tag' }}
+    runs-on: ubuntu-latest
+    needs:
+      - binaries
+      - os-package
+      - config-yaml
+      - desktop
+    steps:
+      - name: Download binaries
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: release_files
+          path: release
+      - name: Download packages
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: vikunja_pkg_*
+          path: release
+          merge-multiple: true
+      - name: Download desktop builds
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: desktop_*
+          path: release
+          merge-multiple: true
+      - name: Download config
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: config_yaml_sample
+          path: release
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: release/**
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- upload build artifacts as workflow artifacts
- create a GitHub release from those artifacts when a tag is built

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Argument of type '{}' is not assignable)*
- `pnpm test:unit`
- `mage test:unit` *(failed: signal interrupt)*
- `mage test:integration` *(failed: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6846b1acb0d483209c0c5d5c7c7b19be