### PR TITLE
Add configurable docs links with learn more component

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,7 +22,9 @@
 	// This variable points the frontend to the api.
 	// It has to be the full url, including the last /api/v1 part and port.
 	// You can change this if your api is not reachable on the same port as the frontend.
-	window.API_URL = '/api/v1'
+        window.API_URL = '/api/v1'
+        // Base url for the documentation links
+        window.DOCS_URL = 'https://vikunja.io/docs/'
 </script>
 </body>
 </html>

--- a/frontend/src/components/misc/LearnMore.vue
+++ b/frontend/src/components/misc/LearnMore.vue
@@ -1,0 +1,31 @@
+<template>
+	<BaseButton
+		:href="href"
+		target="_blank"
+		class="tw-text-xs tw-text-gray-400 inline-flex items-center gap-1"
+	>
+		<Icon
+			icon="circle-question"
+			class="tw-w-4 tw-h-4"
+		/>
+		{{ $t('misc.learnMore') }}
+	</BaseButton>
+</template>
+
+<script setup lang="ts">
+import {computed} from 'vue'
+import BaseButton from '@/components/base/BaseButton.vue'
+import Icon from '@/components/misc/Icon'
+import {DOCS_URL} from '@/urls'
+
+const props = defineProps<{
+    path?: string
+}>()
+
+const href = computed(() => {
+    if (!props.path) return DOCS_URL
+    const cleaned = props.path.replace(/^\/+/, '')
+    return `${DOCS_URL}${cleaned}`
+})
+</script>
+

--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -593,7 +593,8 @@
     "createdBy": "Created by {0}",
     "actions": "Actions",
     "cannotBeUndone": "This cannot be undone!",
-    "avatarOfUser": "{user}'s profile image"
+    "avatarOfUser": "{user}'s profile image",
+    "learnMore": "Learn more"
   },
   "input": {
     "resetColor": "Reset Color",

--- a/frontend/src/urls.ts
+++ b/frontend/src/urls.ts
@@ -1,2 +1,6 @@
 export const POWERED_BY = 'https://vikunja.io/?utm_source=powered_by'
-export const CALDAV_DOCS = 'https://vikunja.io/docs/caldav/'
+
+// Use a configurable docs url which falls back to the official Vikunja docs
+export const DOCS_URL = (window.DOCS_URL || 'https://vikunja.io/docs/').replace(/\/?$/, '/')
+
+export const CALDAV_DOCS = `${DOCS_URL}caldav/`

--- a/frontend/src/views/project/settings/ProjectSettingsWebhooks.vue
+++ b/frontend/src/views/project/settings/ProjectSettingsWebhooks.vue
@@ -20,7 +20,7 @@ import WebhookService from '@/services/webhook'
 import {formatDateShort} from '@/helpers/time/formatDate'
 import User from '@/components/misc/User.vue'
 import WebhookModel from '@/models/webhook'
-import BaseButton from '@/components/base/BaseButton.vue'
+import LearnMore from '@/components/misc/LearnMore.vue'
 import FancyCheckbox from '@/components/input/FancyCheckbox.vue'
 import {success} from '@/message'
 import {isValidHttpUrl} from '@/helpers/isValidHttpUrl'
@@ -176,9 +176,7 @@ function validateSelectedEvents() {
 				</div>
 				<p class="help">
 					{{ $t('project.webhooks.secretHint') }}
-					<BaseButton href="https://vikunja.io/docs/webhooks/">
-						{{ $t('project.webhooks.secretDocs') }}
-					</BaseButton>
+					<LearnMore path="webhooks/#secrets" />
 				</p>
 			</div>
 			<div class="field">

--- a/frontend/src/views/user/settings/Caldav.vue
+++ b/frontend/src/views/user/settings/Caldav.vue
@@ -88,12 +88,7 @@
 		</XButton>
 
 		<p>
-			<BaseButton
-				:href="CALDAV_DOCS"
-				target="_blank"
-			>
-				{{ $t('user.settings.caldav.more') }}
-			</BaseButton>
+			<LearnMore path="caldav/" />
 		</p>
 	</Card>
 </template>
@@ -102,11 +97,10 @@
 import {computed, ref, shallowReactive} from 'vue'
 import {useI18n} from 'vue-i18n'
 
-import {CALDAV_DOCS} from '@/urls'
 import {useTitle} from '@/composables/useTitle'
 import {useCopyToClipboard} from '@/composables/useCopyToClipboard'
 import {success} from '@/message'
-import BaseButton from '@/components/base/BaseButton.vue'
+import LearnMore from '@/components/misc/LearnMore.vue'
 import Message from '@/components/misc/Message.vue'
 import CaldavTokenService from '@/services/caldavToken'
 import { formatDateShort } from '@/helpers/time/formatDate'


### PR DESCRIPTION
## Summary
- add docs url constant and default config
- create `LearnMore` component for help links
- use help links in Webhooks and CalDAV settings
- provide English i18n string for learn more

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: TS errors in existing files)*
- `pnpm test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68472f401bd88320bc932617fe58dac0