### PR TITLE
Expose db close and shut down engine

### DIFF
--- a/pkg/cmd/web.go
+++ b/pkg/cmd/web.go
@@ -28,6 +28,7 @@ import (
 
 	"code.vikunja.io/api/pkg/config"
 	"code.vikunja.io/api/pkg/cron"
+	"code.vikunja.io/api/pkg/db"
 	"code.vikunja.io/api/pkg/initialize"
 	"code.vikunja.io/api/pkg/log"
 	"code.vikunja.io/api/pkg/routes"
@@ -157,6 +158,9 @@ var webCmd = &cobra.Command{
 		defer cancel()
 		log.Infof("Shutting down...")
 		if err := e.Shutdown(ctx); err != nil {
+			e.Logger.Fatal(err)
+		}
+		if err := db.Close(); err != nil {
 			e.Logger.Fatal(err)
 		}
 		cron.Stop()

--- a/pkg/db/db.go
+++ b/pkg/db/db.go
@@ -239,3 +239,11 @@ func GetDialect() string {
 
 	return dialect
 }
+
+// Close closes the database engine.
+func Close() error {
+	if x == nil {
+		return nil
+	}
+	return x.Close()
+}


### PR DESCRIPTION
## Summary
- expose database engine `Close()` helper
- close the DB after shutting down web server

## Testing
- `mage lint`
- `mage test:unit` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6847c77146ec83209261f7d3f99f0105