### PR TITLE
Use Go module cache in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version: stable
+          cache: true
+          cache-dependency-path: go.sum
       - name: Cache Mage
         id: cache-mage
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
@@ -48,6 +50,8 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version: stable
+          cache: true
+          cache-dependency-path: go.sum
       - name: Build
         env:
           RELEASE_VERSION: ${{ steps.ghd.outputs.describe }}
@@ -69,6 +73,8 @@ jobs:
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version: stable
+          cache: true
+          cache-dependency-path: go.sum
       - name: prepare frontend files
         run: |
           mkdir -p frontend/dist
@@ -205,6 +211,8 @@ jobs:
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5
         with:
           go-version: stable
+          cache: true
+          cache-dependency-path: go.sum
       - name: Configure Postgres for faster tests
         if: matrix.db == 'postgres'
         run: |


### PR DESCRIPTION
## Summary
- enable caching in setup-go steps of API build, lint, and test jobs
- reuse Go module cache when compiling Mage

## Testing
- `mage lint` *(failed: signal interrupt)*
- `mage test:unit` *(failed: truncated after timeout)*
- `mage test:integration` *(failed: signal interrupt)*
- `pnpm lint`
- `pnpm typecheck` *(fails: TS errors)*


------
https://chatgpt.com/codex/tasks/task_e_6847cbe7b5f4832096ba87e12e29222f