### PR TITLE
Debounce team member search

### DIFF
--- a/frontend/src/constants/search.ts
+++ b/frontend/src/constants/search.ts
@@ -1,0 +1,1 @@
+export const SEARCH_DELAY = 300


### PR DESCRIPTION
## Summary
- debounce user search when editing teams
- debounce search in sharing user/team components
- centralize search delay constant

## Testing
- `pnpm lint` *(fails: pnpm not found)*
- `pnpm typecheck` *(fails: pnpm not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ff167fc083208746a040e43d890d