### PR TITLE
Refactor sidebar layout to use CSS grid

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,8 +1,10 @@
 <template>
 	<Ready>
 		<template v-if="authStore.authUser">
-			<AppHeader />
-			<ContentAuth />
+			<div class="app-layout">
+				<AppHeader />
+				<ContentAuth />
+			</div>
 		</template>
 		<ContentLinkShare v-else-if="authStore.authLinkShare" />
 		<NoAuthWrapper
@@ -93,3 +95,11 @@ useColorScheme()
 </script>
 
 <style lang="scss" src="@/styles/global.scss" />
+
+<style lang="scss">
+.app-layout {
+       display: grid;
+       grid-template-rows: min-content 1fr;
+       min-height: 100vh;
+}
+</style>

--- a/frontend/src/components/home/AppHeader.vue
+++ b/frontend/src/components/home/AppHeader.vue
@@ -155,10 +155,9 @@ $user-dropdown-width-mobile: 5rem;
 	--navbar-gap-width: 1rem;
 	--navbar-icon-size: 1.25rem;
 
-	position: fixed;
-	top: 0;
-	left: 0;
-	right: 0;
+       position: sticky;
+       top: 0;
+       z-index: 30;
 
 	display: flex;
 	justify-content: space-between;

--- a/frontend/src/components/home/ContentAuth.vue
+++ b/frontend/src/components/home/ContentAuth.vue
@@ -17,52 +17,56 @@
 				class="app-container-background background-fade-in d-print-none"
 				:style="{'background-image': background && `url(${background})`}"
 			/>
-			<Navigation class="d-print-none" />
-			<main
-				class="app-content"
-				:class="[
-					{ 'is-menu-enabled': menuActive },
-					$route.name,
-				]"
+			<div
+				class="sidebar-layout"
+				:class="{'is-menu-enabled': menuActive}"
 			>
-				<BaseButton
-					v-show="menuActive"
-					class="mobile-overlay d-print-none"
-					@click="baseStore.setMenuActive(false)"
-				/>
-
-				<QuickActions />
-
-				<RouterView
-					v-slot="{ Component }"
-					:route="routeWithModal"
+				<Navigation class="d-print-none" />
+				<main
+					class="app-content"
+					:class="[
+						$route.name,
+					]"
 				>
-					<keep-alive :include="['project.view']">
-						<component :is="Component" />
-					</keep-alive>
-				</RouterView>
-
-				<Modal
-					:enabled="typeof currentModal !== 'undefined'"
-					variant="scrolling"
-					class="task-detail-view-modal"
-					@close="closeModal()"
-				>
-					<component
-						:is="currentModal"
-						@close="closeModal()"
+					<BaseButton
+						v-show="menuActive"
+						class="mobile-overlay d-print-none"
+						@click="baseStore.setMenuActive(false)"
 					/>
-				</Modal>
 
-				<BaseButton
-					v-shortcut="'?'"
-					class="keyboard-shortcuts-button d-print-none"
-					@click="showKeyboardShortcuts()"
-				>
-					<span class="sr-only">{{ $t('keyboardShortcuts.title') }}</span>
-					<Icon icon="keyboard" />
-				</BaseButton>
-			</main>
+					<QuickActions />
+
+					<RouterView
+						v-slot="{ Component }"
+						:route="routeWithModal"
+					>
+						<keep-alive :include="['project.view']">
+							<component :is="Component" />
+						</keep-alive>
+					</RouterView>
+
+					<Modal
+						:enabled="typeof currentModal !== 'undefined'"
+						variant="scrolling"
+						class="task-detail-view-modal"
+						@close="closeModal()"
+					>
+						<component
+							:is="currentModal"
+							@close="closeModal()"
+						/>
+					</Modal>
+
+					<BaseButton
+						v-shortcut="'?'"
+						class="keyboard-shortcuts-button d-print-none"
+						@click="showKeyboardShortcuts()"
+					>
+						<span class="sr-only">{{ $t('keyboardShortcuts.title') }}</span>
+						<Icon icon="keyboard" />
+					</BaseButton>
+				</main>
+			</div>
 		</div>
 	</div>
 </template>
@@ -155,41 +159,41 @@ projectStore.loadAllProjects()
 	}
 }
 
-.app-container {
-	min-height: calc(100vh - 65px);
 
-	@media screen and (max-width: $tablet) {
-		padding-top: $navbar-height;
-	}
+.app-container {
+       min-height: 100vh;
+}
+
+.sidebar-layout {
+       display: grid;
+       grid-template-columns: 0 1fr;
+       min-height: 100%;
+       transition: grid-template-columns $transition-duration;
+
+       &.is-menu-enabled {
+               grid-template-columns: $navbar-width 1fr;
+       }
 }
 
 .app-content {
-	display: flow-root;
-	z-index: 10;
-	position: relative;
-	padding: 1.5rem 0.5rem 0;
-	// TODO refactor: DRY `transition-timing-function` with `./Navigation.vue`.
-	transition: margin-left $transition-duration;
+        display: flow-root;
+        z-index: 10;
+        position: relative;
+       padding: 1.5rem 0.5rem 0;
+        // TODO refactor: DRY `transition-timing-function` with `./Navigation.vue`.
 
-	@media screen and (max-width: $tablet) {
-		margin-left: 0;
-		min-height: calc(100vh - 4rem);
-	}
+       @media screen and (max-width: $tablet) {
+               min-height: 100vh;
+       }
 
-	@media screen and (min-width: $tablet) {
-		padding: $navbar-height + 1.5rem 1.5rem 0 1.5rem;
-	}
-
-	&.is-menu-enabled {
-		@media screen and (min-width: $tablet) {
-			margin-left: $navbar-width;
-		}
-	}
+       @media screen and (min-width: $tablet) {
+               padding: 1.5rem 1.5rem 0 1.5rem;
+       }
 
 	// Used to make sure the spinner is always in the middle while loading
-	> .loader-container {
-		min-height: calc(100vh - #{$navbar-height + 1.5rem + 1rem});
-	}
+       > .loader-container {
+               min-height: calc(100vh - 2.5rem);
+       }
 
 	// FIXME: This should be somehow defined inside Card.vue
 	.card {

--- a/frontend/src/components/home/Navigation.vue
+++ b/frontend/src/components/home/Navigation.vue
@@ -149,30 +149,31 @@ const savedFilterProjects = computed(() => projectStore.savedFilterProjects)
 }
 
 .menu-container {
-	display: flex;
-	flex-direction: column;
-	background: var(--site-background);
-	color: $vikunja-nav-color;
-	padding: 1rem 0;
-	transition: transform $transition-duration ease-in;
-	position: fixed;
-	top: $navbar-height;
-	bottom: 0;
-	left: 0;
-	transform: translateX(-100%);
-	width: $navbar-width;
-	overflow-y: auto;
+       display: flex;
+       flex-direction: column;
+       background: var(--site-background);
+       color: $vikunja-nav-color;
+       padding: 1rem 0;
+       transition: transform $transition-duration ease-in;
+       position: sticky;
+       top: 0;
+       left: 0;
+       width: $navbar-width;
+       height: 100vh;
+       overflow-y: auto;
+       transform: translateX(-100%);
 
-	@media screen and (max-width: $tablet) {
-		top: 0;
-		width: 70vw;
-		z-index: 20;
-	}
+       @media screen and (max-width: $tablet) {
+               position: fixed;
+               bottom: 0;
+               width: 70vw;
+               z-index: 20;
+       }
 
-	&.is-active {
-		transform: translateX(0);
-		transition: transform $transition-duration ease-out;
-	}
+       &.is-active {
+               transform: translateX(0);
+               transition: transform $transition-duration ease-out;
+       }
 }
 
 .top-menu .menu-list {


### PR DESCRIPTION
## Summary
- use a grid container so the sidebar no longer relies on padding
- switch the sidebar to `position: sticky`
- drop margin-based layout logic for the content area

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Caldav.vue TS2345, Deletion.vue TS2345, General.vue TS18047, ...)*
- `pnpm test:unit` *(fails: Command failed with exit code 130)*

------
https://chatgpt.com/codex/tasks/task_e_6848250350848320a0da2f7586fdf03e