### PR TITLE
Make the table header row sticky

### DIFF
--- a/frontend/src/components/project/views/ProjectTable.vue
+++ b/frontend/src/components/project/views/ProjectTable.vue
@@ -386,10 +386,19 @@ const taskDetailRoutes = computed(() => Object.fromEntries(
 </script>
 
 <style lang="scss" scoped>
+
 .table {
-	background: transparent;
-	overflow-x: auto;
-	overflow-y: hidden;
+       --sticky-header-z-index: 10;
+       background: transparent;
+       overflow-x: auto;
+       overflow-y: hidden;
+
+       thead tr {
+               position: sticky;
+               top: $navbar-height + 1.5rem;
+               z-index: var(--sticky-header-z-index);
+               background: var(--white);
+       }
 
 	th {
 		white-space: nowrap;


### PR DESCRIPTION
## Summary
- update ProjectTable view styles to keep the header row visible while scrolling

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: see logs)*
- `pnpm test:unit`
- `mage test:unit` *(fails: interrupted)*
- `mage test:integration` *(fails: interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_684824ce088c8320a8ff5c631308b6e7