### PR TITLE
Fix dropTableColumn name

### DIFF
--- a/pkg/migration/20190324205606.go
+++ b/pkg/migration/20190324205606.go
@@ -35,7 +35,7 @@ func init() {
 		ID:          "20190324205606",
 		Description: "Remove reminders_unix from tasks",
 		Migrate: func(tx *xorm.Engine) error {
-			return dropTableColum(tx, "tasks", "reminders_unix")
+			return dropTableColumn(tx, "tasks", "reminders_unix")
 		},
 		Rollback: func(tx *xorm.Engine) error {
 			return tx.Sync2(tasksReminderDateMigration20190324205606{})

--- a/pkg/migration/20190328074430.go
+++ b/pkg/migration/20190328074430.go
@@ -35,7 +35,7 @@ func init() {
 		ID:          "20190328074430",
 		Description: "Remove updated from team_members",
 		Migrate: func(tx *xorm.Engine) error {
-			return dropTableColum(tx, "team_members", "updated")
+			return dropTableColumn(tx, "team_members", "updated")
 		},
 		Rollback: func(tx *xorm.Engine) error {
 			return tx.Sync2(teamMembersMigration20190328074430{})

--- a/pkg/migration/20190430111111.go
+++ b/pkg/migration/20190430111111.go
@@ -37,7 +37,7 @@ func init() {
 			return tx.Sync2(listTask20190430111111{})
 		},
 		Rollback: func(tx *xorm.Engine) error {
-			return dropTableColum(tx, "tasks", "hex_color")
+			return dropTableColumn(tx, "tasks", "hex_color")
 		},
 	})
 }

--- a/pkg/migration/20190511202210.go
+++ b/pkg/migration/20190511202210.go
@@ -87,7 +87,7 @@ func init() {
 			return nil
 		},
 		Rollback: func(tx *xorm.Engine) error {
-			return dropTableColum(tx, "tasks", "uid")
+			return dropTableColumn(tx, "tasks", "uid")
 		},
 	})
 }

--- a/pkg/migration/20190514192749.go
+++ b/pkg/migration/20190514192749.go
@@ -37,7 +37,7 @@ func init() {
 			return tx.Sync2(listTask20190514192749{})
 		},
 		Rollback: func(tx *xorm.Engine) error {
-			return dropTableColum(tx, "tasks", "done_at_unix")
+			return dropTableColumn(tx, "tasks", "done_at_unix")
 		},
 	})
 }

--- a/pkg/migration/20190524205441.go
+++ b/pkg/migration/20190524205441.go
@@ -61,7 +61,7 @@ func init() {
 				return err
 			}
 
-			return dropTableColum(tx, "tasks", "reminders_unix")
+			return dropTableColumn(tx, "tasks", "reminders_unix")
 		},
 		Rollback: func(tx *xorm.Engine) error {
 			return tx.DropTables(taskReminder20190524205441{})

--- a/pkg/migration/20190920185205.go
+++ b/pkg/migration/20190920185205.go
@@ -37,7 +37,7 @@ func init() {
 			return tx.Sync2(task20190920185205{})
 		},
 		Rollback: func(tx *xorm.Engine) error {
-			return dropTableColum(tx, "tasks", "percent_done")
+			return dropTableColumn(tx, "tasks", "percent_done")
 		},
 	})
 }

--- a/pkg/migration/20190922205826.go
+++ b/pkg/migration/20190922205826.go
@@ -86,7 +86,7 @@ func init() {
 				return err
 			}
 
-			return dropTableColum(tx, "tasks", "parent_task_id")
+			return dropTableColumn(tx, "tasks", "parent_task_id")
 		},
 		Rollback: func(tx *xorm.Engine) error {
 			return tx.DropTables(taskRelation20190922205826{})

--- a/pkg/migration/20191207204427.go
+++ b/pkg/migration/20191207204427.go
@@ -37,7 +37,7 @@ func init() {
 			return tx.Sync2(list20191207204427{})
 		},
 		Rollback: func(tx *xorm.Engine) error {
-			return dropTableColum(tx, "list", "indentifier")
+			return dropTableColumn(tx, "list", "indentifier")
 		},
 	})
 }

--- a/pkg/migration/20191207220736.go
+++ b/pkg/migration/20191207220736.go
@@ -70,7 +70,7 @@ func init() {
 			return nil
 		},
 		Rollback: func(tx *xorm.Engine) error {
-			return dropTableColum(tx, "tasks", "index")
+			return dropTableColumn(tx, "tasks", "index")
 		},
 	})
 }

--- a/pkg/migration/20200120201756.go
+++ b/pkg/migration/20200120201756.go
@@ -40,7 +40,7 @@ func init() {
 			return tx.Sync2(status20200120201756{})
 		},
 		Rollback: func(tx *xorm.Engine) error {
-			return dropTableColum(tx, "migration_status", "index")
+			return dropTableColumn(tx, "migration_status", "index")
 		},
 	})
 

--- a/pkg/migration/20200515172220.go
+++ b/pkg/migration/20200515172220.go
@@ -111,7 +111,7 @@ create unique index tasks_id_uindex
 				return err
 			}
 
-			return dropTableColum(tx, "tasks", "text")
+			return dropTableColumn(tx, "tasks", "text")
 		},
 		Rollback: func(tx *xorm.Engine) error {
 			return nil

--- a/pkg/migration/20200515195546.go
+++ b/pkg/migration/20200515195546.go
@@ -99,7 +99,7 @@ create unique index UQE_namespaces_id
 				return err
 			}
 
-			return dropTableColum(tx, "namespaces", "name")
+			return dropTableColumn(tx, "namespaces", "name")
 		},
 		Rollback: func(tx *xorm.Engine) error {
 			return nil

--- a/pkg/migration/20210709211508.go
+++ b/pkg/migration/20210709211508.go
@@ -98,12 +98,12 @@ func init() {
 				}
 			}
 
-			err = dropTableColum(tx, "tasks", "is_favorite")
+			err = dropTableColumn(tx, "tasks", "is_favorite")
 			if err != nil {
 				return err
 			}
 
-			return dropTableColum(tx, "lists", "is_favorite")
+			return dropTableColumn(tx, "lists", "is_favorite")
 		},
 		Rollback: func(tx *xorm.Engine) error {
 			return nil

--- a/pkg/migration/20210711173657.go
+++ b/pkg/migration/20210711173657.go
@@ -90,11 +90,11 @@ func init() {
 				}
 			}
 
-			err = dropTableColum(tx, "users", "password_reset_token")
+			err = dropTableColumn(tx, "users", "password_reset_token")
 			if err != nil {
 				return err
 			}
-			return dropTableColum(tx, "users", "email_confirm_token")
+			return dropTableColumn(tx, "users", "email_confirm_token")
 		},
 		Rollback: func(tx *xorm.Engine) error {
 			return nil

--- a/pkg/migration/20210713213622.go
+++ b/pkg/migration/20210713213622.go
@@ -62,7 +62,7 @@ func init() {
 				}
 			}
 
-			return dropTableColum(tx, "users", "is_active")
+			return dropTableColumn(tx, "users", "is_active")
 		},
 		Rollback: func(tx *xorm.Engine) error {
 			return nil

--- a/pkg/migration/20221228112131.go
+++ b/pkg/migration/20221228112131.go
@@ -306,5 +306,5 @@ func removeNamespaceLeftovers(tx *xorm.Engine) error {
 		return err
 	}
 
-	return dropTableColum(tx, "projects", "namespace_id")
+	return dropTableColumn(tx, "projects", "namespace_id")
 }

--- a/pkg/migration/20230903143017.go
+++ b/pkg/migration/20230903143017.go
@@ -109,7 +109,7 @@ func init() {
 				return err
 			}
 
-			return dropTableColum(tx, "buckets", "is_done_bucket")
+			return dropTableColumn(tx, "buckets", "is_done_bucket")
 		},
 		Rollback: func(tx *xorm.Engine) error {
 			return nil

--- a/pkg/migration/20231108231513.go
+++ b/pkg/migration/20231108231513.go
@@ -87,7 +87,7 @@ func init() {
 				return err
 			}
 
-			err = dropTableColum(tx, "migration_status", "created")
+			err = dropTableColumn(tx, "migration_status", "created")
 			return err
 		},
 		Rollback: func(tx *xorm.Engine) error {

--- a/pkg/migration/20240314214802.go
+++ b/pkg/migration/20240314214802.go
@@ -187,11 +187,11 @@ create unique index UQE_tasks_id
 				return err
 			}
 
-			err = dropTableColum(tx, "tasks", "position")
+			err = dropTableColumn(tx, "tasks", "position")
 			if err != nil {
 				return err
 			}
-			return dropTableColum(tx, "tasks", "kanban_position")
+			return dropTableColumn(tx, "tasks", "kanban_position")
 		},
 		Rollback: func(tx *xorm.Engine) error {
 			return nil

--- a/pkg/migration/20240315093418.go
+++ b/pkg/migration/20240315093418.go
@@ -112,7 +112,7 @@ create unique index if not exists UQE_buckets_id
 				return err
 			}
 
-			return dropTableColum(tx, "buckets", "project_id")
+			return dropTableColumn(tx, "buckets", "project_id")
 		},
 		Rollback: func(tx *xorm.Engine) error {
 			return nil

--- a/pkg/migration/20240315104205.go
+++ b/pkg/migration/20240315104205.go
@@ -145,11 +145,11 @@ create unique index UQE_projects_id
 				return err
 			}
 
-			err = dropTableColum(tx, "projects", "done_bucket_id")
+			err = dropTableColumn(tx, "projects", "done_bucket_id")
 			if err != nil {
 				return
 			}
-			return dropTableColum(tx, "projects", "default_bucket_id")
+			return dropTableColumn(tx, "projects", "default_bucket_id")
 		},
 		Rollback: func(tx *xorm.Engine) error {
 			return nil

--- a/pkg/migration/20240315110428.go
+++ b/pkg/migration/20240315110428.go
@@ -176,7 +176,7 @@ create unique index UQE_tasks_id
 				return err
 			}
 
-			return dropTableColum(tx, "tasks", "bucket_id")
+			return dropTableColumn(tx, "tasks", "bucket_id")
 		},
 		Rollback: func(tx *xorm.Engine) error {
 			return nil

--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -115,8 +115,9 @@ func MigrateTo(migrationID string, x *xorm.Engine) error {
 	return m.MigrateTo(migrationID)
 }
 
-// Deletes a column from a table. All arguments are strings, to let them be standalone and not depending on any struct.
-func dropTableColum(x *xorm.Engine, tableName, col string) error {
+// dropTableColumn deletes a column from a table. All arguments are strings, to
+// let them be standalone and not depending on any struct.
+func dropTableColumn(x *xorm.Engine, tableName, col string) error {
 
 	switch config.DatabaseType.GetString() {
 	case "sqlite":
@@ -135,6 +136,14 @@ func dropTableColum(x *xorm.Engine, tableName, col string) error {
 		log.Fatal("Unknown db.")
 	}
 	return nil
+}
+
+// dropTableColum is deprecated and kept for backwards compatibility.
+// Use dropTableColumn instead.
+//
+//nolint:unused
+func dropTableColum(x *xorm.Engine, tableName, col string) error {
+	return dropTableColumn(x, tableName, col)
 }
 
 // Modifies a column definition


### PR DESCRIPTION
## Summary
- rename `dropTableColum` to `dropTableColumn`
- keep a deprecated `dropTableColum` wrapper
- use the new helper in migrations

## Testing
- `mage lint`


------
https://chatgpt.com/codex/tasks/task_e_6846563773ac83208408cd14e0c26c03