### PR TITLE
Fix restore nil check

### DIFF
--- a/pkg/modules/dump/restore.go
+++ b/pkg/modules/dump/restore.go
@@ -122,7 +122,11 @@ func Restore(filename string) error {
 
 	// Because we don't explicitly saved the table definitions, we take the last ran db migration from the dump
 	// and execute everything until that point.
-	migrations := dbfiles["migration"]
+	migrations, ok := dbfiles["migration"]
+	if !ok || migrations == nil {
+		return fmt.Errorf("migration data missing from dump")
+	}
+
 	rc, err := migrations.Open()
 	if err != nil {
 		return fmt.Errorf("could not open migrations: %w", err)


### PR DESCRIPTION
## Summary
- fail restoring when the migration file is missing

## Testing
- `mage lint`

------
https://chatgpt.com/codex/tasks/task_e_684616c6c1488320ad415b9c27f1d63f