### PR TITLE
Fix Postgres bigint migration quoting

### DIFF
--- a/pkg/migration/20201218152741.go
+++ b/pkg/migration/20201218152741.go
@@ -45,7 +45,7 @@ func changeColumnToBigint(x *xorm.Session, table, column string, nullable, defau
 			return err
 		}
 	case "postgres":
-		_, err := x.Exec("ALTER TABLE " + table + " ALTER COLUMN `" + column + "` TYPE BIGINT using `" + column + "`::bigint")
+		_, err := x.Exec("ALTER TABLE \"" + table + "\" ALTER COLUMN \"" + column + "\" TYPE BIGINT USING \"" + column + "\"::bigint")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
- escape Postgres identifiers with `"` for bigint migration

## Testing
- `mage lint`


------
https://chatgpt.com/codex/tasks/task_e_684616ae1a48832090171e4ee23097f7