### PR TITLE
Fix renaming tables on PostgreSQL

### DIFF
--- a/pkg/migration/migration.go
+++ b/pkg/migration/migration.go
@@ -171,7 +171,7 @@ func renameTable(x *xorm.Engine, oldName, newName string) error {
 			return err
 		}
 	case "postgres":
-		_, err := x.Exec("ALTER TABLE `" + oldName + "` RENAME TO `" + newName + "`")
+		_, err := x.Exec("ALTER TABLE \"" + oldName + "\" RENAME TO \"" + newName + "\"")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
- fix quoting of table names for postgres in `renameTable`

## Testing
- `mage lint`


------
https://chatgpt.com/codex/tasks/task_e_684616a65f608320acc4c7a21791e494