### PR TITLE
Fix migration rollback typo

### DIFF
--- a/pkg/migration/20191207204427.go
+++ b/pkg/migration/20191207204427.go
@@ -37,7 +37,7 @@ func init() {
 			return tx.Sync2(list20191207204427{})
 		},
 		Rollback: func(tx *xorm.Engine) error {
-			return dropTableColum(tx, "list", "indentifier")
+			return dropTableColum(tx, "list", "identifier")
 		},
 	})
 }


### PR DESCRIPTION
## Summary
- correct `identifier` typo in migration rollback

## Testing
- `go vet -structtag=false ./...`
- `mage lint`


------
https://chatgpt.com/codex/tasks/task_e_6846169dfc1c832098ed26cd5e03276b