### PR TITLE
Fix CalDAV timestamp parsing without TZID

### DIFF
--- a/pkg/caldav/parsing.go
+++ b/pkg/caldav/parsing.go
@@ -457,23 +457,20 @@ func caldavTimeToTimestamp(ianaProperty ics.IANAProperty) time.Time {
 	var err error
 	tzParameter := ianaProperty.ICalParameters["TZID"]
 	if len(tzParameter) > 0 {
-		loc, err := time.LoadLocation(tzParameter[0])
-		if err != nil {
-			log.Warningf("Error while parsing caldav timezone %s: %s", tzParameter[0], err)
+		loc, locErr := time.LoadLocation(tzParameter[0])
+		if locErr != nil {
+			log.Warningf("Error while parsing caldav timezone %s: %s", tzParameter[0], locErr)
 		} else {
 			t, err = time.ParseInLocation(format, tstring, loc)
-			if err != nil {
-				log.Warningf("Error while parsing caldav time %s to TimeStamp: %s at location %s", tstring, loc, err)
-			} else {
-				t = t.In(config.GetTimeZone())
-				return t
-			}
 		}
+	} else {
+		t, err = time.ParseInLocation(format, tstring, config.GetTimeZone())
 	}
-	t, err = time.Parse(format, tstring)
+
 	if err != nil {
 		log.Warningf("Error while parsing caldav time %s to TimeStamp: %s", tstring, err)
 		return time.Time{}
 	}
-	return t
+
+	return t.In(config.GetTimeZone())
 }

--- a/pkg/caldav/parsing_test.go
+++ b/pkg/caldav/parsing_test.go
@@ -22,6 +22,7 @@ import (
 
 	"code.vikunja.io/api/pkg/config"
 	"code.vikunja.io/api/pkg/models"
+	ics "github.com/arran4/golang-ical"
 	"gopkg.in/d4l3k/messagediff.v1"
 )
 
@@ -720,5 +721,17 @@ END:VCALENDAR`,
 				t.Errorf("GetCaldavTodosForTasks() gotVTask = %v, want %v, diff = %s", got, tt.wantCaldav, diff)
 			}
 		})
+	}
+}
+
+func TestCaldavTimeToTimestamp_NoTZID(t *testing.T) {
+	config.InitDefaultConfig()
+	prop := ics.IANAProperty{BaseProperty: ics.BaseProperty{Value: "20181201T011204", ICalParameters: map[string][]string{}}}
+
+	got := caldavTimeToTimestamp(prop)
+	want := time.Date(2018, 12, 1, 1, 12, 4, 0, config.GetTimeZone())
+
+	if !got.Equal(want) || got.Location().String() != config.GetTimeZone().String() {
+		t.Fatalf("caldavTimeToTimestamp() = %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- parse CalDAV timestamps without TZID in configured timezone
- return results converted to configured timezone
- test timezone handling when TZID is missing

## Testing
- `mage lint`
- `mage test:unit`
- `mage test:integration`

------
https://chatgpt.com/codex/tasks/task_e_6846166f91fc83209570c7416f517e47