### PR TITLE
Add timezone-aware helper

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -35,7 +35,8 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"time"
+
+	"code.vikunja.io/api/pkg/utils"
 
 	"github.com/iancoleman/strcase"
 	"github.com/magefile/mage/mg"
@@ -1006,7 +1007,7 @@ func (Dev) MakeMigration() error {
 	str, _ := reader.ReadString('\n')
 	str = strings.Trim(str, "\n")
 
-	date := time.Now().Format("20060102150405")
+	date := utils.Now().Format("20060102150405")
 
 	migration := `// Vikunja is a to-do list application to facilitate your life.
 // Copyright 2018-present Vikunja and contributors. All rights reserved.

--- a/pkg/cmd/dump.go
+++ b/pkg/cmd/dump.go
@@ -19,7 +19,8 @@ package cmd
 import (
 	"path/filepath"
 	"strings"
-	"time"
+
+	"code.vikunja.io/api/pkg/utils"
 
 	"code.vikunja.io/api/pkg/config"
 	"code.vikunja.io/api/pkg/initialize"
@@ -45,7 +46,7 @@ var dumpCmd = &cobra.Command{
 		initialize.FullInitWithoutAsync()
 	},
 	Run: func(_ *cobra.Command, _ []string) {
-		filename := "vikunja-dump_" + time.Now().Format("2006-01-02_15-03-05") + ".zip"
+		filename := "vikunja-dump_" + utils.Now().Format("2006-01-02_15-03-05") + ".zip"
 		if dumpFilenameFlag != "" {
 			filename = dumpFilenameFlag
 			if !strings.HasSuffix(filename, ".zip") {

--- a/pkg/initialize/init.go
+++ b/pkg/initialize/init.go
@@ -17,7 +17,7 @@
 package initialize
 
 import (
-	"time"
+	"code.vikunja.io/api/pkg/utils"
 
 	"code.vikunja.io/api/pkg/config"
 	"code.vikunja.io/api/pkg/cron"
@@ -117,7 +117,7 @@ func FullInit() {
 		}
 
 		err = events.Dispatch(&BootedEvent{
-			BootedAt: time.Now(),
+			BootedAt: utils.Now(),
 		})
 		if err != nil {
 			log.Fatal(err)

--- a/pkg/metrics/active_users.go
+++ b/pkg/metrics/active_users.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 	"time"
 
+	"code.vikunja.io/api/pkg/utils"
+
 	"code.vikunja.io/api/pkg/log"
 	"code.vikunja.io/api/pkg/modules/keyvalue"
 	"code.vikunja.io/api/pkg/web"
@@ -126,7 +128,7 @@ func SetUserActive(a web.Auth) (err error) {
 	defer activeUsers.mutex.Unlock()
 	activeUsers.users[a.GetID()] = &ActiveAuthenticable{
 		ID:       a.GetID(),
-		LastSeen: time.Now(),
+		LastSeen: utils.Now(),
 	}
 
 	return keyvalue.Put(activeUsersKey, activeUsers.users)
@@ -138,7 +140,7 @@ func SetLinkShareActive(a web.Auth) (err error) {
 	defer activeLinkShares.mutex.Unlock()
 	activeLinkShares.shares[a.GetID()] = &ActiveAuthenticable{
 		ID:       a.GetID(),
-		LastSeen: time.Now(),
+		LastSeen: utils.Now(),
 	}
 
 	return keyvalue.Put(activeLinkSharesKey, activeLinkShares.shares)

--- a/pkg/models/export.go
+++ b/pkg/models/export.go
@@ -47,7 +47,7 @@ func ExportUserData(s *xorm.Session, u *user.User) (err error) {
 		return err
 	}
 
-	tmpFilename := exportDir + strconv.FormatInt(u.ID, 10) + "_" + time.Now().Format("2006-01-02_15-03-05") + ".zip"
+	tmpFilename := exportDir + strconv.FormatInt(u.ID, 10) + "_" + utils.Now().Format("2006-01-02_15-03-05") + ".zip"
 
 	// Open zip
 	dumpFile, err := os.Create(tmpFilename)
@@ -389,7 +389,7 @@ func RegisterOldExportCleanupCron() {
 		}
 
 		fs := []*files.File{}
-		err = s.Where("created < ?", time.Now().Add(-time.Hour*24*7)).In("id", fileIDs).Find(&fs)
+		err = s.Where("created < ?", utils.Now().Add(-time.Hour*24*7)).In("id", fileIDs).Find(&fs)
 		if err != nil {
 			log.Errorf(logPrefix+"Could not get users with export files: %s", err)
 			return

--- a/pkg/models/kanban.go
+++ b/pkg/models/kanban.go
@@ -21,6 +21,8 @@ import (
 	"strings"
 	"time"
 
+	"code.vikunja.io/api/pkg/utils"
+
 	"code.vikunja.io/api/pkg/log"
 	"code.vikunja.io/api/pkg/user"
 	"code.vikunja.io/api/pkg/web"
@@ -175,8 +177,8 @@ func GetTasksInBucketsForView(s *xorm.Session, view *ProjectView, projects []*Pr
 				ProjectViewID: view.ID,
 				Position:      float64(id),
 				CreatedByID:   auth.GetID(),
-				Created:       time.Now(),
-				Updated:       time.Now(),
+				Created:       utils.Now(),
+				Updated:       utils.Now(),
 			})
 		}
 	}

--- a/pkg/models/kanban_task_bucket.go
+++ b/pkg/models/kanban_task_bucket.go
@@ -19,6 +19,8 @@ package models
 import (
 	"time"
 
+	"code.vikunja.io/api/pkg/utils"
+
 	"code.vikunja.io/api/pkg/events"
 	"code.vikunja.io/api/pkg/user"
 	"code.vikunja.io/api/pkg/web"
@@ -155,7 +157,7 @@ func (b *TaskBucket) Update(s *xorm.Session, a web.Auth) (err error) {
 
 	if doneChanged {
 		if task.Done {
-			task.DoneAt = time.Now()
+			task.DoneAt = utils.Now()
 		} else {
 			task.DoneAt = time.Time{}
 		}

--- a/pkg/models/listeners.go
+++ b/pkg/models/listeners.go
@@ -22,6 +22,8 @@ import (
 	"strconv"
 	"time"
 
+	"code.vikunja.io/api/pkg/utils"
+
 	"code.vikunja.io/api/pkg/config"
 	"code.vikunja.io/api/pkg/db"
 	"code.vikunja.io/api/pkg/events"
@@ -989,7 +991,7 @@ func (wl *WebhookListener) Handle(msg *message.Message) (err error) {
 
 		err = webhook.sendWebhookPayload(&WebhookPayload{
 			EventName: wl.EventName,
-			Time:      time.Now(),
+			Time:      utils.Now(),
 			Data:      event,
 		})
 		if err != nil {

--- a/pkg/models/project.go
+++ b/pkg/models/project.go
@@ -154,8 +154,8 @@ var FavoritesPseudoProject = Project{
 		},
 	},
 
-	Created: time.Now(),
-	Updated: time.Now(),
+	Created: utils.Now(),
+	Updated: utils.Now(),
 }
 
 // ReadAll gets all projects a user has access to

--- a/pkg/models/task_collection_filter_test.go
+++ b/pkg/models/task_collection_filter_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"code.vikunja.io/api/pkg/utils"
+
 	"code.vikunja.io/api/pkg/db"
 
 	"github.com/stretchr/testify/assert"
@@ -114,7 +116,7 @@ func TestParseFilter(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, result, 1)
 		assert.Equal(t, "due_date", result[0].field)
-		in30Days := time.Now().Add(time.Hour * 24 * 30)
+		in30Days := utils.Now().Add(time.Hour * 24 * 30)
 		assert.Equal(t, in30Days.Unix(), result[0].value.(time.Time).Unix())
 	})
 	t.Run("date math strings with quotes", func(t *testing.T) {
@@ -123,7 +125,7 @@ func TestParseFilter(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, result, 1)
 		assert.Equal(t, "due_date", result[0].field)
-		in30Days := time.Now().Add(time.Hour * 24 * 30)
+		in30Days := utils.Now().Add(time.Hour * 24 * 30)
 		assert.Equal(t, in30Days.Unix(), result[0].value.(time.Time).Unix())
 	})
 	t.Run("string values with single quotes", func(t *testing.T) {
@@ -269,7 +271,7 @@ func TestParseFilter(t *testing.T) {
 		require.Len(t, result, 1)
 		assert.Equal(t, "done_at", result[0].field)
 		assert.Equal(t, taskFilterComparatorGreater, result[0].comparator)
-		sevenDaysAgo := time.Now().Add(-7 * 24 * time.Hour)
+		sevenDaysAgo := utils.Now().Add(-7 * 24 * time.Hour)
 		assert.Equal(t, sevenDaysAgo.Unix(), result[0].value.(time.Time).Unix())
 	})
 	t.Run("date filter with 0000-01-01", func(t *testing.T) {

--- a/pkg/models/task_overdue_reminder.go
+++ b/pkg/models/task_overdue_reminder.go
@@ -123,7 +123,7 @@ func RegisterOverdueReminderCron() {
 		s := db.NewSession()
 		defer s.Close()
 
-		now := time.Now()
+		now := utils.Now()
 		uts, err := getUndoneOverdueTasks(s, now)
 		if err != nil {
 			log.Errorf("[Undone Overdue Tasks Reminder] Could not get undone overdue tasks in the next minute: %s", err)

--- a/pkg/models/task_reminder.go
+++ b/pkg/models/task_reminder.go
@@ -277,7 +277,7 @@ func RegisterReminderCron() {
 		s := db.NewSession()
 		defer s.Close()
 
-		now := time.Now()
+		now := utils.Now()
 		reminders, err := getTasksWithRemindersDueAndTheirUsers(s, now)
 		if err != nil {
 			log.Errorf("[Task Reminder Cron] Could not get tasks with reminders in the next minute: %s", err)

--- a/pkg/models/tasks.go
+++ b/pkg/models/tasks.go
@@ -1362,7 +1362,7 @@ func setTaskDatesDefault(oldTask, newTask *Task) {
 	}
 
 	// Current time in an extra variable to base all calculations on the same time
-	now := time.Now()
+	now := utils.Now()
 
 	repeatDuration := time.Duration(oldTask.RepeatAfter) * time.Second
 
@@ -1427,7 +1427,7 @@ func setTaskDatesFromCurrentDateRepeat(oldTask, newTask *Task) {
 	}
 
 	// Current time in an extra variable to base all calculations on the same time
-	now := time.Now()
+	now := utils.Now()
 
 	repeatDuration := time.Duration(oldTask.RepeatAfter) * time.Second
 
@@ -1505,7 +1505,7 @@ func updateDone(oldTask *Task, newTask *Task) {
 			setTaskDatesDefault(oldTask, newTask)
 		}
 
-		newTask.DoneAt = time.Now()
+		newTask.DoneAt = utils.Now()
 	}
 
 	// When unmarking a task as done, reset the timestamp

--- a/pkg/models/tasks_test.go
+++ b/pkg/models/tasks_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	"code.vikunja.io/api/pkg/utils"
+
 	"code.vikunja.io/api/pkg/db"
 	"code.vikunja.io/api/pkg/events"
 	"code.vikunja.io/api/pkg/user"
@@ -618,7 +620,7 @@ func TestUpdateDone(t *testing.T) {
 			oldTask := &Task{
 				Done:        false,
 				RepeatAfter: 8600,
-				DueDate:     time.Now().Add(time.Hour),
+				DueDate:     utils.Now().Add(time.Hour),
 			}
 			newTask := &Task{
 				Done: true,
@@ -642,7 +644,7 @@ func TestUpdateDone(t *testing.T) {
 				updateDone(oldTask, newTask)
 
 				// Only comparing unix timestamps because time.Time use nanoseconds which can't ever possibly have the same value
-				assert.Equal(t, time.Now().Add(time.Duration(oldTask.RepeatAfter)*time.Second).Unix(), newTask.DueDate.Unix())
+				assert.Equal(t, utils.Now().Add(time.Duration(oldTask.RepeatAfter)*time.Second).Unix(), newTask.DueDate.Unix())
 				assert.False(t, newTask.Done)
 			})
 			t.Run("reminders", func(t *testing.T) {
@@ -667,8 +669,8 @@ func TestUpdateDone(t *testing.T) {
 
 				assert.Len(t, newTask.Reminders, 2)
 				// Only comparing unix timestamps because time.Time use nanoseconds which can't ever possibly have the same value
-				assert.Equal(t, time.Now().Add(time.Duration(oldTask.RepeatAfter)*time.Second).Unix(), newTask.Reminders[0].Reminder.Unix())
-				assert.Equal(t, time.Now().Add(diff+time.Duration(oldTask.RepeatAfter)*time.Second).Unix(), newTask.Reminders[1].Reminder.Unix())
+				assert.Equal(t, utils.Now().Add(time.Duration(oldTask.RepeatAfter)*time.Second).Unix(), newTask.Reminders[0].Reminder.Unix())
+				assert.Equal(t, utils.Now().Add(diff+time.Duration(oldTask.RepeatAfter)*time.Second).Unix(), newTask.Reminders[1].Reminder.Unix())
 				assert.False(t, newTask.Done)
 			})
 			t.Run("start date", func(t *testing.T) {
@@ -684,7 +686,7 @@ func TestUpdateDone(t *testing.T) {
 				updateDone(oldTask, newTask)
 
 				// Only comparing unix timestamps because time.Time use nanoseconds which can't ever possibly have the same value
-				assert.Equal(t, time.Now().Add(time.Duration(oldTask.RepeatAfter)*time.Second).Unix(), newTask.StartDate.Unix())
+				assert.Equal(t, utils.Now().Add(time.Duration(oldTask.RepeatAfter)*time.Second).Unix(), newTask.StartDate.Unix())
 				assert.False(t, newTask.Done)
 			})
 			t.Run("end date", func(t *testing.T) {
@@ -700,7 +702,7 @@ func TestUpdateDone(t *testing.T) {
 				updateDone(oldTask, newTask)
 
 				// Only comparing unix timestamps because time.Time use nanoseconds which can't ever possibly have the same value
-				assert.Equal(t, time.Now().Add(time.Duration(oldTask.RepeatAfter)*time.Second).Unix(), newTask.EndDate.Unix())
+				assert.Equal(t, utils.Now().Add(time.Duration(oldTask.RepeatAfter)*time.Second).Unix(), newTask.EndDate.Unix())
 				assert.False(t, newTask.Done)
 			})
 			t.Run("start and end date", func(t *testing.T) {
@@ -719,8 +721,8 @@ func TestUpdateDone(t *testing.T) {
 				diff := oldTask.EndDate.Sub(oldTask.StartDate)
 
 				// Only comparing unix timestamps because time.Time use nanoseconds which can't ever possibly have the same value
-				assert.Equal(t, time.Now().Add(time.Duration(oldTask.RepeatAfter)*time.Second).Unix(), newTask.StartDate.Unix())
-				assert.Equal(t, time.Now().Add(diff+time.Duration(oldTask.RepeatAfter)*time.Second).Unix(), newTask.EndDate.Unix())
+				assert.Equal(t, utils.Now().Add(time.Duration(oldTask.RepeatAfter)*time.Second).Unix(), newTask.StartDate.Unix())
+				assert.Equal(t, utils.Now().Add(diff+time.Duration(oldTask.RepeatAfter)*time.Second).Unix(), newTask.EndDate.Unix())
 				assert.False(t, newTask.Done)
 			})
 		})

--- a/pkg/models/typesense.go
+++ b/pkg/models/typesense.go
@@ -22,6 +22,8 @@ import (
 	"strconv"
 	"time"
 
+	"code.vikunja.io/api/pkg/utils"
+
 	"code.vikunja.io/api/pkg/config"
 	"code.vikunja.io/api/pkg/db"
 	"code.vikunja.io/api/pkg/log"
@@ -213,7 +215,7 @@ func ReindexAllTasks() (err error) {
 
 	currentSync := &TypesenseSync{
 		Collection:    "tasks",
-		SyncStartedAt: time.Now(),
+		SyncStartedAt: utils.Now(),
 	}
 	_, err = s.Insert(currentSync)
 	if err != nil {
@@ -236,7 +238,7 @@ func ReindexAllTasks() (err error) {
 		return fmt.Errorf("could not reindex all tasks: %s", err.Error())
 	}
 
-	currentSync.SyncFinishedAt = time.Now()
+	currentSync.SyncFinishedAt = utils.Now()
 	_, err = s.Where("collection = ?", "tasks").
 		Cols("sync_finished_at").
 		Update(currentSync)
@@ -360,16 +362,16 @@ func indexDummyTask() (err error) {
 	dummyTask := &typesenseTask{
 		ID:      "-100",
 		Title:   "Dummytask",
-		Created: time.Now().Unix(),
-		Updated: time.Now().Unix(),
+		Created: utils.Now().Unix(),
+		Updated: utils.Now().Unix(),
 		Reminders: []*TaskReminder{
 			{
 				ID:             -10,
 				TaskID:         -100,
-				Reminder:       time.Now(),
+				Reminder:       utils.Now(),
 				RelativePeriod: 10,
 				RelativeTo:     ReminderRelationDueDate,
-				Created:        time.Now(),
+				Created:        utils.Now(),
 			},
 		},
 		Assignees: []*user.User{
@@ -378,8 +380,8 @@ func indexDummyTask() (err error) {
 				Username: "dummy",
 				Name:     "dummy",
 				Email:    "dummy@vikunja",
-				Created:  time.Now(),
-				Updated:  time.Now(),
+				Created:  utils.Now(),
+				Updated:  utils.Now(),
 			},
 		},
 		Labels: []*Label{
@@ -388,30 +390,30 @@ func indexDummyTask() (err error) {
 				Title:       "dummylabel",
 				Description: "Lorem Ipsum Dummy",
 				HexColor:    "000000",
-				Created:     time.Now(),
-				Updated:     time.Now(),
+				Created:     utils.Now(),
+				Updated:     utils.Now(),
 			},
 		},
 		Attachments: []*TaskAttachment{
 			{
 				ID:      -120,
 				TaskID:  -100,
-				Created: time.Now(),
+				Created: utils.Now(),
 			},
 		},
 		Comments: []*TaskComment{
 			{
 				ID:      -220,
 				Comment: "Lorem Ipsum Dummy",
-				Created: time.Now(),
-				Updated: time.Now(),
+				Created: utils.Now(),
+				Updated: utils.Now(),
 				Author: &user.User{
 					ID:       -100,
 					Username: "dummy",
 					Name:     "dummy",
 					Email:    "dummy@vikunja",
-					Created:  time.Now(),
-					Updated:  time.Now(),
+					Created:  utils.Now(),
+					Updated:  utils.Now(),
 				},
 			},
 		},
@@ -553,7 +555,7 @@ func SyncUpdatedTasksIntoTypesense() (err error) {
 		return
 	}
 
-	currentSync := &TypesenseSync{SyncStartedAt: time.Now()}
+	currentSync := &TypesenseSync{SyncStartedAt: utils.Now()}
 	_, err = s.Where("collection = ?", "tasks").
 		Cols("sync_started_at", "sync_finished_at").
 		Update(currentSync)
@@ -585,7 +587,7 @@ func SyncUpdatedTasksIntoTypesense() (err error) {
 		log.Debugf("[Typesense Sync] No tasks changed since the last sync, not syncing")
 	}
 
-	currentSync.SyncFinishedAt = time.Now()
+	currentSync.SyncFinishedAt = utils.Now()
 	_, err = s.Where("collection = ?", "tasks").
 		Cols("sync_finished_at").
 		Update(currentSync)

--- a/pkg/models/user_delete.go
+++ b/pkg/models/user_delete.go
@@ -17,7 +17,7 @@
 package models
 
 import (
-	"time"
+	"code.vikunja.io/api/pkg/utils"
 
 	"code.vikunja.io/api/pkg/cron"
 	"code.vikunja.io/api/pkg/db"
@@ -43,7 +43,7 @@ func RegisterUserDeletionCron() {
 func deleteUsers() {
 	s := db.NewSession()
 	users := []*user.User{}
-	err := s.Where(builder.Lt{"deletion_scheduled_at": time.Now()}).
+	err := s.Where(builder.Lt{"deletion_scheduled_at": utils.Now()}).
 		Find(&users)
 	if err != nil {
 		log.Errorf("Could not get users scheduled for deletion: %s", err)
@@ -56,7 +56,7 @@ func deleteUsers() {
 
 	log.Debugf("Found %d users scheduled for deletion", len(users))
 
-	now := time.Now()
+	now := utils.Now()
 
 	for _, u := range users {
 		if !u.DeletionScheduledAt.Before(now) {

--- a/pkg/modules/auth/auth.go
+++ b/pkg/modules/auth/auth.go
@@ -21,6 +21,8 @@ import (
 	"net/http"
 	"time"
 
+	"code.vikunja.io/api/pkg/utils"
+
 	"code.vikunja.io/api/pkg/config"
 	"code.vikunja.io/api/pkg/db"
 	"code.vikunja.io/api/pkg/models"
@@ -63,7 +65,7 @@ func NewUserJWTAuthtoken(u *user.User, long bool) (token string, err error) {
 	if long {
 		ttl = time.Duration(config.ServiceJWTTTLLong.GetInt64())
 	}
-	var exp = time.Now().Add(time.Second * ttl).Unix()
+	var exp = utils.Now().Add(time.Second * ttl).Unix()
 
 	// Set claims
 	claims := t.Claims.(jwt.MapClaims)
@@ -86,7 +88,7 @@ func NewLinkShareJWTAuthtoken(share *models.LinkSharing) (token string, err erro
 	t := jwt.New(jwt.SigningMethodHS256)
 
 	var ttl = time.Duration(config.ServiceJWTTTL.GetInt64())
-	var exp = time.Now().Add(time.Second * ttl).Unix()
+	var exp = utils.Now().Add(time.Second * ttl).Unix()
 
 	// Set claims
 	claims := t.Claims.(jwt.MapClaims)

--- a/pkg/modules/avatar/gravatar/gravatar.go
+++ b/pkg/modules/avatar/gravatar/gravatar.go
@@ -92,7 +92,7 @@ func (g *Provider) GetAvatar(user *user.User, size int64) ([]byte, string, error
 		av = avatar{
 			Content:  avatarContent,
 			MimeType: mimeType,
-			LoadedAt: time.Now(),
+			LoadedAt: utils.Now(),
 		}
 
 		// Store in keyvalue cache

--- a/pkg/modules/background/unsplash/unsplash.go
+++ b/pkg/modules/background/unsplash/unsplash.go
@@ -26,6 +26,8 @@ import (
 	"strings"
 	"time"
 
+	"code.vikunja.io/api/pkg/utils"
+
 	"xorm.io/xorm"
 
 	"code.vikunja.io/api/pkg/config"
@@ -200,7 +202,7 @@ func (p *Provider) Search(_ *xorm.Session, search string, page int64) (result []
 			}
 		}
 
-		emptySearchResult.lastCached = time.Now()
+		emptySearchResult.lastCached = utils.Now()
 		emptySearchResult.images[page] = result
 
 		return

--- a/pkg/modules/migration/migration_status.go
+++ b/pkg/modules/migration/migration_status.go
@@ -21,6 +21,7 @@ import (
 
 	"code.vikunja.io/api/pkg/db"
 	"code.vikunja.io/api/pkg/user"
+	"code.vikunja.io/api/pkg/utils"
 )
 
 // Status represents this migration status
@@ -45,7 +46,7 @@ func StartMigration(m MigratorName, u *user.User) (status *Status, err error) {
 	status = &Status{
 		UserID:       u.ID,
 		MigratorName: m.Name(),
-		StartedAt:    time.Now(),
+		StartedAt:    utils.Now(),
 	}
 	_, err = s.Insert(status)
 	return
@@ -56,7 +57,7 @@ func FinishMigration(status *Status) (err error) {
 	s := db.NewSession()
 	defer s.Close()
 
-	status.FinishedAt = time.Now()
+	status.FinishedAt = utils.Now()
 
 	_, err = s.Where("id = ?", status.ID).Update(status)
 	return

--- a/pkg/notifications/database.go
+++ b/pkg/notifications/database.go
@@ -19,6 +19,7 @@ package notifications
 import (
 	"time"
 
+	"code.vikunja.io/api/pkg/utils"
 	"xorm.io/xorm"
 )
 
@@ -88,7 +89,7 @@ func CanMarkNotificationAsRead(s *xorm.Session, notification *DatabaseNotificati
 func MarkNotificationAsRead(s *xorm.Session, notification *DatabaseNotification, read bool) (err error) {
 	notification.ReadAt = time.Time{}
 	if read {
-		notification.ReadAt = time.Now()
+		notification.ReadAt = utils.Now()
 	}
 
 	_, err = s.
@@ -102,6 +103,6 @@ func MarkAllNotificationsAsRead(s *xorm.Session, userID int64) (err error) {
 	_, err = s.
 		Where("notifiable_id = ?", userID).
 		Cols("read_at").
-		Update(&DatabaseNotification{ReadAt: time.Now()})
+		Update(&DatabaseNotification{ReadAt: utils.Now()})
 	return
 }

--- a/pkg/routes/api_tokens.go
+++ b/pkg/routes/api_tokens.go
@@ -19,7 +19,8 @@ package routes
 import (
 	"net/http"
 	"strings"
-	"time"
+
+	"code.vikunja.io/api/pkg/utils"
 
 	"code.vikunja.io/api/pkg/config"
 	"code.vikunja.io/api/pkg/db"
@@ -77,7 +78,7 @@ func checkAPITokenAndPutItInContext(tokenHeaderValue string, c echo.Context) err
 		return echo.NewHTTPError(http.StatusInternalServerError).SetInternal(err)
 	}
 
-	if time.Now().After(token.ExpiresAt) {
+	if utils.Now().After(token.ExpiresAt) {
 		log.Debugf("[auth] Tried authenticating with token %d but it expired on %s", token.ID, token.ExpiresAt.String())
 		return echo.NewHTTPError(http.StatusUnauthorized)
 	}

--- a/pkg/user/delete.go
+++ b/pkg/user/delete.go
@@ -19,6 +19,8 @@ package user
 import (
 	"time"
 
+	"code.vikunja.io/api/pkg/utils"
+
 	"code.vikunja.io/api/pkg/cron"
 	"code.vikunja.io/api/pkg/db"
 	"code.vikunja.io/api/pkg/log"
@@ -75,7 +77,7 @@ func notifyUsersScheduledForDeletion() {
 			continue
 		}
 
-		user.DeletionLastReminderSent = time.Now()
+		user.DeletionLastReminderSent = utils.Now()
 		_, err = s.Where("id = ?", user.ID).
 			Cols("deletion_last_reminder_sent").
 			Update(user)
@@ -115,7 +117,7 @@ func ConfirmDeletion(s *xorm.Session, user *User, token string) (err error) {
 		return err
 	}
 
-	user.DeletionScheduledAt = time.Now().Add(3 * 24 * time.Hour)
+	user.DeletionScheduledAt = utils.Now().Add(3 * 24 * time.Hour)
 	_, err = s.Where("id = ?", user.ID).
 		Cols("deletion_scheduled_at").
 		Update(user)

--- a/pkg/user/token.go
+++ b/pkg/user/token.go
@@ -131,7 +131,7 @@ func RegisterTokenCleanupCron() {
 		defer s.Close()
 
 		deleted, err := s.
-			Where("created > ? AND (kind = ? OR kind = ?)", time.Now().Add(time.Hour*24*-1), TokenPasswordReset, TokenAccountDeletion).
+			Where("created > ? AND (kind = ? OR kind = ?)", utils.Now().Add(time.Hour*24*-1), TokenPasswordReset, TokenAccountDeletion).
 			Delete(&Token{})
 		if err != nil {
 			log.Errorf(logPrefix+"Error removing old password reset tokens: %s", err)

--- a/pkg/utils/time.go
+++ b/pkg/utils/time.go
@@ -39,3 +39,8 @@ func GetTimeWithoutSeconds(t time.Time) time.Time {
 	// so we make sure the time we use to get the reminders don't contain nanoseconds.
 	return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), 0, 0, t.Location()).In(tz)
 }
+
+// Now returns the current time in the configured timezone.
+func Now() time.Time {
+	return time.Now().In(config.GetTimeZone())
+}


### PR DESCRIPTION
## Summary
- add `utils.Now()` for timezone-aware timestamps
- use helper instead of `time.Now()` throughout the backend

## Testing
- `mage lint`
- `mage test:unit` *(fails: numerous test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68461672cb388320ab4bae75b330c550