### PR TITLE
Fix default timezone initialization

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -596,7 +596,7 @@ func InitConfig() {
 		MigrationMicrosoftTodoRedirectURL.Set(ServicePublicURL.GetString() + "migrate/microsoft-todo")
 	}
 
-	if DefaultSettingsTimezone.GetString() == "" {
+	if tz := DefaultSettingsTimezone.GetString(); tz == "" || tz == "<time zone set at service.timezone>" {
 		DefaultSettingsTimezone.Set(ServiceTimeZone.GetString())
 	}
 }


### PR DESCRIPTION
## Summary
- ensure the default user timezone falls back to `service.timezone` when the placeholder value is still present

## Testing
- `mage lint`
- `mage test:unit`
- `mage test:integration`


------
https://chatgpt.com/codex/tasks/task_e_684613a26e948320b40bd4a2c886e189