### PR TITLE
chore: remove unused type prop in UserTeam share component

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS
+
+These instructions summarize the development guidelines from the official Vikunja docs and CI workflows. They apply to the entire repository.
+
+## Development Environment
+- Use [devenv](https://devenv.sh/) to get a shell with all required tools.
+
+## Building From Source
+1. Clone the repo and check out the desired version.
+
+2. **Frontend**:
+	- Requires Node.js (version defined in `frontend/.nvmrc`) and pnpm (install via corepack).
+	- Run `pnpm install --frozen-lockfile` inside `frontend/`.
+	- Build with `pnpm run build` to create the `dist/` bundle.
+	- Lint with `pnpm lint` and run TypeScript checks with `pnpm typecheck`.
+	- Run frontend unit tests with `pnpm test:unit`.
+3. **API**:
+	- Requires Go (use version from `go.mod`) and Mage.
+	- If the frontend bundle is missing, build it or create a dummy file with `mkdir -p frontend/dist && touch frontend/dist/index.html`.
+	- Build with `mage build`.
+	- Lint with `mage lint` and run `mage check:translations` when translation files change.
+4. Cross‑compile with `mage release` or `mage release:{linux|windows|darwin}`.
+
+## Formatting
+- Respect the formatting rules from `.editorconfig` in the repository root and all subfolders.
+- Adhere to the ESLint rules defined in `frontend/eslint.config.js`. Run `pnpm lint` (or `pnpm lint:fix`) to check and automatically fix issues.
+
+## Testing
+- Set `VIKUNJA_SERVICE_ROOTPATH` to the repository root before running tests so fixtures load correctly.
+- Run API unit tests with `mage test:unit`.
+- Run API integration tests with `mage test:integration`.
+- Run frontend unit tests with `pnpm test:unit` (run `pnpm install --frozen-lockfile` in `frontend/` first).
+- Run `pnpm lint` and `pnpm typecheck` to match CI checks. `typecheck` might fail. Only make sure you don't create new issues.
+
+## Pull Requests
+- PRs must be opened against the `main` branch.
+- Keep PRs small and focused. Allow maintainers to edit your branch.
+- Describe the problem in the PR title and provide a summary in the first comment.
+- If the PR changes the UI, include after screenshots.
+- Reference issues with `Fixes/Closes/Resolves #<number>` each on its own line.
+- Conventional Commit messages are appreciated but not mandatory.

--- a/frontend/src/components/sharing/UserTeam.vue
+++ b/frontend/src/components/sharing/UserTeam.vue
@@ -189,16 +189,14 @@ import {useAuthStore} from '@/stores/auth'
 import {useConfigStore} from '@/stores/config'
 import User from '@/components/misc/User.vue'
 
-// FIXME: I think this whole thing can now only manage user/team sharing for projects? Maybe remove a little generalization?
+// Manages user or team sharing for projects.
 
 const props = withDefaults(defineProps<{
-	type?: 'project',
-	shareType: 'user' | 'team',
-	id: number,
-	userIsAdmin?: boolean
+       shareType: 'user' | 'team',
+       id: number,
+       userIsAdmin?: boolean
 }>(), {
-	type: 'project',
-	userIsAdmin: false,
+       userIsAdmin: false,
 })
 
 const {t} = useI18n({useScope: 'global'})
@@ -238,38 +236,24 @@ function createShareTypeNameComputed(count: number) {
 const shareTypeNames = createShareTypeNameComputed(2)
 const shareTypeName = createShareTypeNameComputed(1)
 
-const sharableName = computed(() => {
-	if (props.type === 'project') {
-		return t('project.list.title')
-	}
-
-	return ''
-})
+const sharableName = computed(() => t('project.list.title'))
 
 if (props.shareType === 'user') {
-	searchService = shallowReactive(new UserService())
-	sharable = ref(new UserModel())
-	searchLabel.value = 'username'
+       searchService = shallowReactive(new UserService())
+       sharable = ref(new UserModel())
+       searchLabel.value = 'username'
 
-	if (props.type === 'project') {
-		stuffService = shallowReactive(new UserProjectService())
-		stuffModel = reactive(new UserProjectModel({projectId: props.id}))
-	} else {
-		throw new Error('Unknown type: ' + props.type)
-	}
+       stuffService = shallowReactive(new UserProjectService())
+       stuffModel = reactive(new UserProjectModel({projectId: props.id}))
 } else if (props.shareType === 'team') {
-	searchService = new TeamService()
-	sharable = ref(new TeamModel())
-	searchLabel.value = 'name'
+       searchService = new TeamService()
+       sharable = ref(new TeamModel())
+       searchLabel.value = 'name'
 
-	if (props.type === 'project') {
-		stuffService = shallowReactive(new TeamProjectService())
-		stuffModel = reactive(new TeamProjectModel({projectId: props.id}))
-	} else {
-		throw new Error('Unknown type: ' + props.type)
-	}
+       stuffService = shallowReactive(new TeamProjectService())
+       stuffModel = reactive(new TeamProjectModel({projectId: props.id}))
 } else {
-	throw new Error('Unkown share type')
+       throw new Error('Unkown share type')
 }
 
 load()


### PR DESCRIPTION
## Summary
- simplify `UserTeam` props
- drop obsolete `type` prop logic

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: ELIFECYCLE)*
- `pnpm test:unit --run`


------
https://chatgpt.com/codex/tasks/task_e_68454039f97483209ab5be70da79dcf8