### PR TITLE
Highlight color picker after reset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS
+
+These instructions summarize the development guidelines from the official Vikunja docs and CI workflows. They apply to the entire repository.
+
+## Development Environment
+- Use [devenv](https://devenv.sh/) to get a shell with all required tools.
+
+## Building From Source
+1. Clone the repo and check out the desired version.
+
+2. **Frontend**:
+	- Requires Node.js (version defined in `frontend/.nvmrc`) and pnpm (install via corepack).
+	- Run `pnpm install --frozen-lockfile` inside `frontend/`.
+	- Build with `pnpm run build` to create the `dist/` bundle.
+	- Lint with `pnpm lint` and run TypeScript checks with `pnpm typecheck`.
+	- Run frontend unit tests with `pnpm test:unit`.
+3. **API**:
+	- Requires Go (use version from `go.mod`) and Mage.
+	- If the frontend bundle is missing, build it or create a dummy file with `mkdir -p frontend/dist && touch frontend/dist/index.html`.
+	- Build with `mage build`.
+	- Lint with `mage lint` and run `mage check:translations` when translation files change.
+4. Cross‑compile with `mage release` or `mage release:{linux|windows|darwin}`.
+
+## Formatting
+- Respect the formatting rules from `.editorconfig` in the repository root and all subfolders.
+- Adhere to the ESLint rules defined in `frontend/eslint.config.js`. Run `pnpm lint` (or `pnpm lint:fix`) to check and automatically fix issues.
+
+## Testing
+- Set `VIKUNJA_SERVICE_ROOTPATH` to the repository root before running tests so fixtures load correctly.
+- Run API unit tests with `mage test:unit`.
+- Run API integration tests with `mage test:integration`.
+- Run frontend unit tests with `pnpm test:unit` (run `pnpm install --frozen-lockfile` in `frontend/` first).
+- Run `pnpm lint` and `pnpm typecheck` to match CI checks. `typecheck` might fail. Only make sure you don't create new issues.
+
+## Pull Requests
+- PRs must be opened against the `main` branch.
+- Keep PRs small and focused. Allow maintainers to edit your branch.
+- Describe the problem in the PR title and provide a summary in the first comment.
+- If the PR changes the UI, include after screenshots.
+- Reference issues with `Fixes/Closes/Resolves #<number>` each on its own line.
+- Conventional Commit messages are appreciated but not mandatory.

--- a/frontend/src/components/input/ColorPicker.test.ts
+++ b/frontend/src/components/input/ColorPicker.test.ts
@@ -1,0 +1,36 @@
+import {mount} from '@vue/test-utils'
+import {describe, expect, it, vi} from 'vitest'
+import ColorPicker from './ColorPicker.vue'
+
+const XButtonStub = {
+    template: '<button @click="$emit(\'click\')"><slot /></button>'
+}
+
+describe('ColorPicker reset', () => {
+    it('clears the color and highlights input', async () => {
+        vi.useFakeTimers()
+        const wrapper = mount(ColorPicker, {
+            props: { modelValue: '#ffffff' },
+            global: {
+                stubs: { XButton: XButtonStub },
+                config: { globalProperties: { $t: (k: string) => k } },
+            },
+        })
+        await wrapper.find('button').trigger('click')
+        await wrapper.vm.$nextTick()
+
+        const input = wrapper.find('input')
+        expect(input.classes()).toContain('was-reset')
+
+        vi.advanceTimersByTime(500)
+        await wrapper.vm.$nextTick()
+
+        const emits = wrapper.emitted()['update:modelValue']
+        expect(emits[emits.length - 1][0]).toBe('')
+
+        vi.advanceTimersByTime(1000)
+        await wrapper.vm.$nextTick()
+        expect(input.classes()).not.toContain('was-reset')
+        vi.useRealTimers()
+    })
+})

--- a/frontend/src/components/input/ColorPicker.vue
+++ b/frontend/src/components/input/ColorPicker.vue
@@ -14,7 +14,7 @@
 				class="picker__input"
 				type="color"
 				:list="colorListID"
-				:class="{'is-empty': isEmpty}"
+				:class="{'is-empty': isEmpty, 'was-reset': wasReset}"
 			>
 			<svg
 				v-show="isEmpty"
@@ -82,6 +82,7 @@ const DEFAULT_COLORS = [
 ]
 
 const color = ref('')
+const wasReset = ref(false)
 const lastChangeTimeout = ref<ReturnType<typeof setTimeout> | null>(null)
 const defaultColors = ref(DEFAULT_COLORS)
 const colorListID = ref(createRandomID())
@@ -122,10 +123,12 @@ function update(force = false) {
 }
 
 function reset() {
-	// FIXME: I havn't found a way to make it clear to the user the color war reset.
-	//  Not sure if verte is capable of this - it does not show the change when setting this.color = ''
-	color.value = ''
-	update(true)
+       color.value = ''
+       wasReset.value = true
+       setTimeout(() => {
+               wasReset.value = false
+       }, 1000)
+       update(true)
 }
 </script>
 
@@ -170,9 +173,22 @@ function reset() {
 		height: $PICKER_SIZE - 2 * $BORDER_WIDTH;
 	}
 
-	.picker__input.is-empty {
-		opacity: 0;
-	}
+        .picker__input.is-empty {
+                opacity: 0;
+        }
+
+        .picker__input.was-reset {
+                animation: color-reset-highlight 1s ease-out;
+        }
+
+        @keyframes color-reset-highlight {
+                from {
+                        box-shadow: 0 0 0 2px var(--primary);
+                }
+                to {
+                        box-shadow: none;
+                }
+        }
 	
 	.picker__pattern {
 		pointer-events: none;


### PR DESCRIPTION
## Summary
- briefly highlight ColorPicker input when resetting
- ensure highlight disappears after 1s
- test the reset behaviour

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: various existing errors)*
- `pnpm test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6845402e1cc88320812d060c243bee57