### PR TITLE
Add PROPPATCH CalDAV test

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS
+
+These instructions summarize the development guidelines from the official Vikunja docs and CI workflows. They apply to the entire repository.
+
+## Development Environment
+- Use [devenv](https://devenv.sh/) to get a shell with all required tools.
+
+## Building From Source
+1. Clone the repo and check out the desired version.
+
+2. **Frontend**:
+	- Requires Node.js (version defined in `frontend/.nvmrc`) and pnpm (install via corepack).
+	- Run `pnpm install --frozen-lockfile` inside `frontend/`.
+	- Build with `pnpm run build` to create the `dist/` bundle.
+	- Lint with `pnpm lint` and run TypeScript checks with `pnpm typecheck`.
+	- Run frontend unit tests with `pnpm test:unit`.
+3. **API**:
+	- Requires Go (use version from `go.mod`) and Mage.
+	- If the frontend bundle is missing, build it or create a dummy file with `mkdir -p frontend/dist && touch frontend/dist/index.html`.
+	- Build with `mage build`.
+	- Lint with `mage lint` and run `mage check:translations` when translation files change.
+4. Cross‑compile with `mage release` or `mage release:{linux|windows|darwin}`.
+
+## Formatting
+- Respect the formatting rules from `.editorconfig` in the repository root and all subfolders.
+- Adhere to the ESLint rules defined in `frontend/eslint.config.js`. Run `pnpm lint` (or `pnpm lint:fix`) to check and automatically fix issues.
+
+## Testing
+- Set `VIKUNJA_SERVICE_ROOTPATH` to the repository root before running tests so fixtures load correctly.
+- Run API unit tests with `mage test:unit`.
+- Run API integration tests with `mage test:integration`.
+- Run frontend unit tests with `pnpm test:unit` (run `pnpm install --frozen-lockfile` in `frontend/` first).
+- Run `pnpm lint` and `pnpm typecheck` to match CI checks. `typecheck` might fail. Only make sure you don't create new issues.
+
+## Pull Requests
+- PRs must be opened against the `main` branch.
+- Keep PRs small and focused. Allow maintainers to edit your branch.
+- Describe the problem in the PR title and provide a summary in the first comment.
+- If the PR changes the UI, include after screenshots.
+- Reference issues with `Fixes/Closes/Resolves #<number>` each on its own line.
+- Conventional Commit messages are appreciated but not mandatory.

--- a/pkg/integrations/caldav_test.go
+++ b/pkg/integrations/caldav_test.go
@@ -79,6 +79,25 @@ END:VCALENDAR`
 		assert.Contains(t, rec.Body.String(), "ACTION:DISPLAY")
 		assert.Contains(t, rec.Body.String(), "END:VALARM")
 	})
+	t.Run("PROPPATCH on task", func(t *testing.T) {
+		const proppatchBody = `<?xml version="1.0" encoding="UTF-8"?>
+<propertyupdate xmlns="DAV:">
+<set>
+<prop>
+<displayname>Updated Task</displayname>
+</prop>
+</set>
+</propertyupdate>`
+
+		e, _ := setupTestEnv()
+		rec, err := newCaldavTestRequestWithUser(t, e, "PROPPATCH", caldav.TaskHandler, &testuser15, proppatchBody, nil, map[string]string{"project": "36", "task": "uid-caldav-test"})
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusNotImplemented, rec.Result().StatusCode)
+
+		rec, err = newCaldavTestRequestWithUser(t, e, http.MethodGet, caldav.TaskHandler, &testuser15, ``, nil, map[string]string{"project": "36", "task": "uid-caldav-test"})
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Result().StatusCode)
+	})
 }
 
 func TestCaldavSubtasks(t *testing.T) {


### PR DESCRIPTION
## Summary
- add PROPPATCH test to caldav integration tests

## Testing
- `VIKUNJA_SERVICE_ROOTPATH=$(pwd) go test ./pkg/integrations -run TestCaldav/PROPPATCH_on_task -count=1 -v`

------
https://chatgpt.com/codex/tasks/task_e_68452da6f64083208f24c14b77b67fe8