### PR TITLE
Add RFC3339 date parsing tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS
+
+These instructions summarize the development guidelines from the official Vikunja docs and CI workflows. They apply to the entire repository.
+
+## Development Environment
+- Use [devenv](https://devenv.sh/) to get a shell with all required tools.
+
+## Building From Source
+1. Clone the repo and check out the desired version.
+
+2. **Frontend**:
+	- Requires Node.js (version defined in `frontend/.nvmrc`) and pnpm (install via corepack).
+	- Run `pnpm install --frozen-lockfile` inside `frontend/`.
+	- Build with `pnpm run build` to create the `dist/` bundle.
+	- Lint with `pnpm lint` and run TypeScript checks with `pnpm typecheck`.
+	- Run frontend unit tests with `pnpm test:unit`.
+3. **API**:
+	- Requires Go (use version from `go.mod`) and Mage.
+	- If the frontend bundle is missing, build it or create a dummy file with `mkdir -p frontend/dist && touch frontend/dist/index.html`.
+	- Build with `mage build`.
+	- Lint with `mage lint` and run `mage check:translations` when translation files change.
+4. Cross‑compile with `mage release` or `mage release:{linux|windows|darwin}`.
+
+## Formatting
+- Respect the formatting rules from `.editorconfig` in the repository root and all subfolders.
+- Adhere to the ESLint rules defined in `frontend/eslint.config.js`. Run `pnpm lint` (or `pnpm lint:fix`) to check and automatically fix issues.
+
+## Testing
+- Set `VIKUNJA_SERVICE_ROOTPATH` to the repository root before running tests so fixtures load correctly.
+- Run API unit tests with `mage test:unit`.
+- Run API integration tests with `mage test:integration`.
+- Run frontend unit tests with `pnpm test:unit` (run `pnpm install --frozen-lockfile` in `frontend/` first).
+- Run `pnpm lint` and `pnpm typecheck` to match CI checks. `typecheck` might fail. Only make sure you don't create new issues.
+
+## Pull Requests
+- PRs must be opened against the `main` branch.
+- Keep PRs small and focused. Allow maintainers to edit your branch.
+- Describe the problem in the PR title and provide a summary in the first comment.
+- If the PR changes the UI, include after screenshots.
+- Reference issues with `Fixes/Closes/Resolves #<number>` each on its own line.
+- Conventional Commit messages are appreciated but not mandatory.

--- a/pkg/caldav/parsing.go
+++ b/pkg/caldav/parsing.go
@@ -445,12 +445,23 @@ func caldavTimeToTimestamp(ianaProperty ics.IANAProperty) time.Time {
 
 	format := DateFormat
 
-	if strings.HasSuffix(tstring, "Z") {
-		format = `20060102T150405Z`
-	}
+	if strings.Contains(tstring, "-") {
+		switch {
+		case len(tstring) == len("2006-01-02"):
+			format = "2006-01-02"
+		case strings.Contains(tstring, "."):
+			format = time.RFC3339Nano
+		default:
+			format = time.RFC3339
+		}
+	} else {
+		if strings.HasSuffix(tstring, "Z") {
+			format = `20060102T150405Z`
+		}
 
-	if len(tstring) == 8 {
-		format = `20060102`
+		if len(tstring) == 8 {
+			format = `20060102`
+		}
 	}
 
 	var t time.Time

--- a/pkg/caldav/parsing_test.go
+++ b/pkg/caldav/parsing_test.go
@@ -354,6 +354,28 @@ END:VCALENDAR`,
 			},
 		},
 		{
+			name: "RFC3339 date formats",
+			args: args{content: `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//RandomProdID//EN
+BEGIN:VTODO
+UID:rfc3339uid
+DTSTAMP:2023-04-02T07:41:58Z
+DUE:2023-04-02
+SUMMARY:Task RFC3339
+DESCRIPTION:Lorem Ipsum
+END:VTODO
+END:VCALENDAR`,
+			},
+			wantVTask: &models.Task{
+				Title:       "Task RFC3339",
+				UID:         "rfc3339uid",
+				Description: "Lorem Ipsum",
+				Updated:     time.Date(2023, 4, 2, 7, 41, 58, 0, config.GetTimeZone()),
+				DueDate:     time.Date(2023, 4, 2, 0, 0, 0, 0, config.GetTimeZone()),
+			},
+		},
+		{
 			name: "with apple hex color",
 			args: args{content: `BEGIN:VCALENDAR
 VERSION:2.0


### PR DESCRIPTION
## Summary
- extend `caldavTimeToTimestamp` to handle RFC3339 date/time strings
- add a test case verifying `ParseTaskFromVTODO` works with RFC3339 `DTSTAMP` and `DUE`

## Testing
- `go test ./pkg/caldav -run TestParseTaskFromVTODO -count=1 -v`


------
https://chatgpt.com/codex/tasks/task_e_68452d8414ac8320bd8b66d190a680c2