### PR TITLE
Fix patch path for sass-embedded

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -4,7 +4,7 @@ let
   pkgs-unstable = import inputs.nixpkgs-unstable { system = pkgs.stdenv.system; };
 in {
   scripts.patch-sass-embedded.exec = ''
-  find node_modules/.pnpm/sass-embedded-linux-*/node_modules/sass-embedded-linux-*/dart-sass/src -name dart -print0 | xargs -I {} -0 patchelf --set-interpreter "$(<$NIX_CC/nix-support/dynamic-linker)" {}
+  find node_modules/.pnpm/sass-embedded-linux-*/node_modules/sass-embedded-linux-*/dart-sass/src/dart -print0 | xargs -0 patchelf --set-interpreter "$(<$NIX_CC/nix-support/dynamic-linker)"
   '';
 
   packages = with pkgs-unstable; [


### PR DESCRIPTION
## Summary
- correct the sass-embedded patch command in `devenv.nix`

## Testing
- `mage lint` *(fails: signal interrupt)*
- `mage test:unit` *(fails: signal interrupt)*
- `mage test:integration` *(fails: signal interrupt)*
- `pnpm lint`
- `pnpm typecheck` *(fails with TS errors)*
- `pnpm test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68491e6c210083209f133ecb55de431f