### PR TITLE
Audit DOM element typings

### DIFF
--- a/frontend/src/components/input/AutocompleteDropdown.vue
+++ b/frontend/src/components/input/AutocompleteDropdown.vue
@@ -24,9 +24,9 @@ const state = ref<StateType>('unfocused')
 const val = ref<string>('')
 const model = defineModel<string>()
 
-const suggestionScrollerRef = ref<HTMLInputElement | null>(null)
-const containerRef = ref<HTMLInputElement | null>(null)
-const editorRef = ref<HTMLInputElement | null>(null)
+const suggestionScrollerRef = ref<HTMLElement | null>(null)
+const containerRef = ref<HTMLElement | null>(null)
+const editorRef = ref<HTMLTextAreaElement | null>(null)
 
 watch(
 	() => model.value,

--- a/frontend/src/components/tasks/AddTask.vue
+++ b/frontend/src/components/tasks/AddTask.vue
@@ -103,7 +103,7 @@ const router = useRouter()
 // 	newTaskInput.value.focus()
 // })
 
-const taskAdd = ref<HTMLTextAreaElement | null>(null)
+const taskAdd = ref<HTMLElement | null>(null)
 const taskAddHovered = useElementHover(taskAdd)
 
 const errorMessage = ref('')


### PR DESCRIPTION
## Summary
- make AddTask hover ref an HTMLElement
- correct AutocompleteDropdown refs to match DOM nodes

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Caldav.vue, Deletion.vue, General.vue, TOTP.vue)*

------
https://chatgpt.com/codex/tasks/task_e_68493fd33a5483208e63b07ab13d144c