### PR TITLE
Refactor editor icons to use typed constants

### DIFF
--- a/frontend/src/components/input/editor/EditorToolbar.vue
+++ b/frontend/src/components/input/editor/EditorToolbar.vue
@@ -8,7 +8,7 @@
 				@click="editor.chain().focus().toggleHeading({ level: 1 }).run()"
 			>
 				<span class="icon">
-					<Icon :icon="['fa', 'fa-header']" />
+					<Icon :icon="faHeader" />
 					<span
 						class="icon__lower-text"
 						aria-hidden="true"
@@ -23,7 +23,7 @@
 				@click="editor.chain().focus().toggleHeading({ level: 2 }).run()"
 			>
 				<span class="icon">
-					<Icon :icon="['fa', 'fa-header']" />
+					<Icon :icon="faHeader" />
 					<span
 						class="icon__lower-text"
 						aria-hidden="true"
@@ -38,7 +38,7 @@
 				@click="editor.chain().focus().toggleHeading({ level: 3 }).run()"
 			>
 				<span class="icon">
-					<Icon :icon="['fa', 'fa-header']" />
+					<Icon :icon="faHeader" />
 					<span
 						class="icon__lower-text"
 						aria-hidden="true"
@@ -56,7 +56,7 @@
 				@click="editor.chain().focus().toggleBold().run()"
 			>
 				<span class="icon">
-					<Icon :icon="['fa', 'fa-bold']" />
+					<Icon :icon="faBold" />
 				</span>
 				<span class="tw-sr-only">{{ $t('input.editor.bold') }}</span>
 			</BaseButton>
@@ -67,7 +67,7 @@
 				@click="editor.chain().focus().toggleItalic().run()"
 			>
 				<span class="icon">
-					<Icon :icon="['fa', 'fa-italic']" />
+					<Icon :icon="faItalic" />
 				</span>
 				<span class="tw-sr-only">{{ $t('input.editor.italic') }}</span>
 			</BaseButton>
@@ -78,7 +78,7 @@
 				@click="editor.chain().focus().toggleUnderline().run()"
 			>
 				<span class="icon">
-					<Icon :icon="['fa', 'fa-underline']" />
+					<Icon :icon="faUnderline" />
 				</span>
 				<span class="tw-sr-only">{{ $t('input.editor.underline') }}</span>
 			</BaseButton>
@@ -89,7 +89,7 @@
 				@click="editor.chain().focus().toggleStrike().run()"
 			>
 				<span class="icon">
-					<Icon :icon="['fa', 'fa-strikethrough']" />
+					<Icon :icon="faStrikethrough" />
 				</span>
 				<span class="tw-sr-only">{{ $t('input.editor.strikethrough') }}</span>
 			</BaseButton>
@@ -103,7 +103,7 @@
 				@click="editor.chain().focus().toggleCodeBlock().run()"
 			>
 				<span class="icon">
-					<Icon :icon="['fa', 'fa-code']" />
+					<Icon :icon="faCode" />
 				</span>
 				<span class="tw-sr-only">{{ $t('input.editor.code') }}</span>
 			</BaseButton>
@@ -114,7 +114,7 @@
 				@click="editor.chain().focus().toggleBlockquote().run()"
 			>
 				<span class="icon">
-					<Icon :icon="['fa', 'fa-quote-right']" />
+					<Icon :icon="faQuoteRight" />
 				</span>
 				<span class="tw-sr-only">{{ $t('input.editor.quote') }}</span>
 			</BaseButton>
@@ -128,7 +128,7 @@
 				@click="editor.chain().focus().toggleBulletList().run()"
 			>
 				<span class="icon">
-					<Icon :icon="['fa', 'fa-list-ul']" />
+					<Icon :icon="faListUl" />
 				</span>
 				<span class="tw-sr-only">{{ $t('input.editor.bulletList') }}</span>
 			</BaseButton>
@@ -139,7 +139,7 @@
 				@click="editor.chain().focus().toggleOrderedList().run()"
 			>
 				<span class="icon">
-					<Icon :icon="['fa', 'fa-list-ol']" />
+					<Icon :icon="faListOl" />
 				</span>
 				<span class="tw-sr-only">{{ $t('input.editor.orderedList') }}</span>
 			</BaseButton>
@@ -150,7 +150,7 @@
 				@click="editor.chain().focus().toggleTaskList().run()"
 			>
 				<span class="icon">
-					<Icon icon="fa-list-check" />
+					<Icon :icon="faListCheck" />
 				</span>
 				<span class="tw-sr-only">{{ $t('input.editor.taskList') }}</span>
 			</BaseButton>
@@ -163,7 +163,7 @@
 				@click="e => emit('imageUploadClicked', e)"
 			>
 				<span class="icon">
-					<Icon icon="fa-image" />
+					<Icon :icon="faImage" />
 				</span>
 				<span class="tw-sr-only">{{ $t('input.editor.image') }}</span>
 			</BaseButton>
@@ -178,7 +178,7 @@
 				@click="setLink"
 			>
 				<span class="icon">
-					<Icon :icon="['fa', 'fa-link']" />
+					<Icon :icon="faLink" />
 				</span>
 				<span class="tw-sr-only">{{ $t('input.editor.link') }}</span>
 			</BaseButton>
@@ -190,7 +190,7 @@
 				@click="editor.chain().focus().setParagraph().run()"
 			>
 				<span class="icon">
-					<Icon :icon="['fa', 'fa-paragraph']" />
+					<Icon :icon="faParagraph" />
 				</span>
 				<span class="tw-sr-only">{{ $t('input.editor.text') }}</span>
 			</BaseButton>
@@ -201,7 +201,7 @@
 				@click="editor.chain().focus().setHorizontalRule().run()"
 			>
 				<span class="icon">
-					<Icon :icon="['fa', 'fa-ruler-horizontal']" />
+					<Icon :icon="faRulerHorizontal" />
 				</span>
 				<span class="tw-sr-only">{{ $t('input.editor.horizontalRule') }}</span>
 			</BaseButton>
@@ -214,7 +214,7 @@
 				@click="editor.chain().focus().undo().run()"
 			>
 				<span class="icon">
-					<Icon :icon="['fa', 'fa-undo']" />
+					<Icon :icon="faUndo" />
 				</span>
 				<span class="tw-sr-only">{{ $t('input.editor.undo') }}</span>
 			</BaseButton>
@@ -224,7 +224,7 @@
 				@click="editor.chain().focus().redo().run()"
 			>
 				<span class="icon">
-					<Icon :icon="['fa', 'fa-redo']" />
+					<Icon :icon="faRedo" />
 				</span>
 				<span class="tw-sr-only">{{ $t('input.editor.redo') }}</span>
 			</BaseButton>
@@ -239,7 +239,7 @@
 				@click="toggleTableMode"
 			>
 				<span class="icon">
-					<Icon :icon="['fa', 'fa-table']" />
+					<Icon :icon="faTable" />
 				</span>
 				<span class="tw-sr-only">{{ $t('input.editor.table.title') }}</span>
 			</BaseButton>
@@ -368,6 +368,25 @@ import type {Editor} from '@tiptap/vue-3'
 
 import BaseButton from '@/components/base/BaseButton.vue'
 import {setLinkInEditor} from '@/components/input/editor/setLinkInEditor'
+import {
+       faHeader,
+       faBold,
+       faItalic,
+       faUnderline,
+       faStrikethrough,
+       faCode,
+       faQuoteRight,
+       faListUl,
+       faListOl,
+       faListCheck,
+       faImage,
+       faLink,
+       faParagraph,
+       faRulerHorizontal,
+       faUndo,
+       faRedo,
+       faTable,
+} from '@/components/misc/Icon'
 
 const props = defineProps<{
 	editor: Editor,

--- a/frontend/src/components/input/editor/TipTap.vue
+++ b/frontend/src/components/input/editor/TipTap.vue
@@ -19,7 +19,7 @@
 				:class="{ 'is-active': editor.isActive('bold') }"
 				@click="() => editor?.chain().focus().toggleBold().run()"
 			>
-				<Icon :icon="['fa', 'fa-bold']" />
+				<Icon :icon="faBold" />
 			</BaseButton>
 			<BaseButton
 				v-tooltip="$t('input.editor.italic')"
@@ -27,7 +27,7 @@
 				:class="{ 'is-active': editor.isActive('italic') }"
 				@click="() => editor?.chain().focus().toggleItalic().run()"
 			>
-				<Icon :icon="['fa', 'fa-italic']" />
+				<Icon :icon="faItalic" />
 			</BaseButton>
 			<BaseButton
 				v-tooltip="$t('input.editor.underline')"
@@ -35,7 +35,7 @@
 				:class="{ 'is-active': editor.isActive('underline') }"
 				@click="() => editor?.chain().focus().toggleUnderline().run()"
 			>
-				<Icon :icon="['fa', 'fa-underline']" />
+				<Icon :icon="faUnderline" />
 			</BaseButton>
 			<BaseButton
 				v-tooltip="$t('input.editor.strikethrough')"
@@ -43,7 +43,7 @@
 				:class="{ 'is-active': editor.isActive('strike') }"
 				@click="() => editor?.chain().focus().toggleStrike().run()"
 			>
-				<Icon :icon="['fa', 'fa-strikethrough']" />
+				<Icon :icon="faStrikethrough" />
 			</BaseButton>
 			<BaseButton
 				v-tooltip="$t('input.editor.code')"
@@ -51,7 +51,7 @@
 				:class="{ 'is-active': editor.isActive('code') }"
 				@click="() => editor?.chain().focus().toggleCode().run()"
 			>
-				<Icon :icon="['fa', 'fa-code']" />
+				<Icon :icon="faCode" />
 			</BaseButton>
 			<BaseButton
 				v-tooltip="$t('input.editor.link')"
@@ -59,7 +59,7 @@
 				:class="{ 'is-active': editor.isActive('link') }"
 				@click="setLink"
 			>
-				<Icon :icon="['fa', 'fa-link']" />
+				<Icon :icon="faLink" />
 			</BaseButton>
 		</BubbleMenu>
 
@@ -178,6 +178,14 @@ import AttachmentModel from '@/models/attachment'
 import AttachmentService from '@/services/attachment'
 import BaseButton from '@/components/base/BaseButton.vue'
 import XButton from '@/components/input/Button.vue'
+import {
+       faBold,
+       faItalic,
+       faUnderline,
+       faStrikethrough,
+       faCode,
+       faLink,
+} from '@/components/misc/Icon'
 
 import {isEditorContentEmpty} from '@/helpers/editorContentEmpty'
 import inputPrompt from '@/helpers/inputPrompt'

--- a/frontend/src/components/input/editor/suggestion.ts
+++ b/frontend/src/components/input/editor/suggestion.ts
@@ -2,6 +2,17 @@ import {VueRenderer} from '@tiptap/vue-3'
 import tippy from 'tippy.js'
 
 import CommandsList from './CommandsList.vue'
+import {
+    faFont,
+    faHeader,
+    faListUl,
+    faListOl,
+    faListCheck,
+    faQuoteRight,
+    faCode,
+    faImage,
+    faRulerHorizontal,
+} from '@/components/misc/Icon'
 
 export default function suggestionSetup(t) {
     return {
@@ -10,7 +21,7 @@ export default function suggestionSetup(t) {
                 {
                     title: t('input.editor.text'),
                     description: t('input.editor.textTooltip'),
-                    icon: 'fa-font',
+                    icon: faFont,
                     command: ({editor, range}) => {
                         editor
                             .chain()
@@ -23,7 +34,7 @@ export default function suggestionSetup(t) {
                 {
                     title: t('input.editor.heading1'),
                     description: t('input.editor.heading1Tooltip'),
-                    icon: 'fa-header',
+                    icon: faHeader,
                     command: ({editor, range}) => {
                         editor
                             .chain()
@@ -36,7 +47,7 @@ export default function suggestionSetup(t) {
                 {
                     title: t('input.editor.heading2'),
                     description: t('input.editor.heading2Tooltip'),
-                    icon: 'fa-header',
+                    icon: faHeader,
                     command: ({editor, range}) => {
                         editor
                             .chain()
@@ -49,7 +60,7 @@ export default function suggestionSetup(t) {
                 {
                     title: t('input.editor.heading3'),
                     description: t('input.editor.heading3Tooltip'),
-                    icon: 'fa-header',
+                    icon: faHeader,
                     command: ({editor, range}) => {
                         editor
                             .chain()
@@ -62,7 +73,7 @@ export default function suggestionSetup(t) {
                 {
                     title: t('input.editor.bulletList'),
                     description: t('input.editor.bulletListTooltip'),
-                    icon: 'fa-list-ul',
+                    icon: faListUl,
                     command: ({editor, range}) => {
                         editor
                             .chain()
@@ -75,7 +86,7 @@ export default function suggestionSetup(t) {
                 {
                     title: t('input.editor.orderedList'),
                     description: t('input.editor.orderedListTooltip'),
-                    icon: 'fa-list-ol',
+                    icon: faListOl,
                     command: ({editor, range}) => {
                         editor
                             .chain()
@@ -88,7 +99,7 @@ export default function suggestionSetup(t) {
                 {
                     title: t('input.editor.taskList'),
                     description: t('input.editor.taskListTooltip'),
-                    icon: 'fa-list-check',
+                    icon: faListCheck,
                     command: ({editor, range}) => {
                         editor
                             .chain()
@@ -101,7 +112,7 @@ export default function suggestionSetup(t) {
                 {
                     title: t('input.editor.quote'),
                     description: t('input.editor.quoteTooltip'),
-                    icon: 'fa-quote-right',
+                    icon: faQuoteRight,
                     command: ({editor, range}) => {
                         editor
                             .chain()
@@ -114,7 +125,7 @@ export default function suggestionSetup(t) {
                 {
                     title: t('input.editor.code'),
                     description: t('input.editor.codeTooltip'),
-                    icon: 'fa-code',
+                    icon: faCode,
                     command: ({editor, range}) => {
                         editor
                             .chain()
@@ -127,7 +138,7 @@ export default function suggestionSetup(t) {
                 {
                     title: t('input.editor.image'),
                     description: t('input.editor.imageTooltip'),
-                    icon: 'fa-image',
+                    icon: faImage,
                     command: ({editor, range}) => {
                         editor
                             .chain()
@@ -140,7 +151,7 @@ export default function suggestionSetup(t) {
                 {
                     title: t('input.editor.horizontalRule'),
                     description: t('input.editor.horizontalRuleTooltip'),
-                    icon: 'fa-ruler-horizontal',
+                    icon: faRulerHorizontal,
                     command: ({editor, range}) => {
                         editor
                             .chain()

--- a/frontend/src/components/misc/Icon.ts
+++ b/frontend/src/components/misc/Icon.ts
@@ -96,6 +96,7 @@ import {
 import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome'
 
 import type {FontAwesomeIcon as FontAwesomeIconFixedTypes} from '@/types/vue-fontawesome'
+import type {IconProp} from '@fortawesome/fontawesome-svg-core'
 
 library.add(faBold)
 library.add(faUndo)
@@ -195,6 +196,25 @@ library.add(faRulerHorizontal)
 library.add(faUnderline)
 library.add(faFaceLaugh)
 library.add(faExclamation)
+
+export const faHeader: IconProp = ['fas', 'header']
+export const faBold: IconProp = ['fas', 'bold']
+export const faItalic: IconProp = ['fas', 'italic']
+export const faUnderline: IconProp = ['fas', 'underline']
+export const faStrikethrough: IconProp = ['fas', 'strikethrough']
+export const faCode: IconProp = ['fas', 'code']
+export const faQuoteRight: IconProp = ['fas', 'quote-right']
+export const faListUl: IconProp = ['fas', 'list-ul']
+export const faListOl: IconProp = ['fas', 'list-ol']
+export const faListCheck: IconProp = ['fas', 'list-check']
+export const faImage: IconProp = ['fas', 'image']
+export const faLink: IconProp = ['fas', 'link']
+export const faParagraph: IconProp = ['fas', 'paragraph']
+export const faRulerHorizontal: IconProp = ['fas', 'ruler-horizontal']
+export const faUndo: IconProp = ['fas', 'undo']
+export const faRedo: IconProp = ['fas', 'redo']
+export const faTable: IconProp = ['fas', 'table']
+export const faFont: IconProp = ['fas', 'font']
 
 // overwriting the wrong types
 export default FontAwesomeIcon as unknown as FontAwesomeIconFixedTypes


### PR DESCRIPTION
## Summary
- export typed icon constants from `Icon.ts`
- replace string icon names in editor components with typed constants

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Argument of type '{}' is not assignable to parameter of type 'ICaldavToken', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684940094550832095203da2125c0bc7