### PR TITLE
Fix null checks in composables

### DIFF
--- a/frontend/src/composables/useProjectBackground.ts
+++ b/frontend/src/composables/useProjectBackground.ts
@@ -3,15 +3,18 @@ import ProjectService from '@/services/project'
 import type {IProject} from '@/modelTypes/IProject'
 import {getBlobFromBlurHash} from '@/helpers/getBlobFromBlurHash'
 
-export function useProjectBackground(project: MaybeRefOrGetter<IProject>) {
+export function useProjectBackground(project: MaybeRefOrGetter<IProject | null>) {
 	const background = ref<string | null>(null)
 	const backgroundLoading = ref(false)
 	const blurHashUrl = ref('')
 
-	watch(
-		() => [toValue(project).id, toValue(project)?.backgroundBlurHash] as [IProject['id'], IProject['backgroundBlurHash']],
-		async ([projectId, blurHash], oldValue) => {
-			const projectValue = toValue(project)
+       watch(
+               () => [
+                       toValue(project)?.id ?? null,
+                       toValue(project)?.backgroundBlurHash ?? null,
+               ] as [IProject['id'] | null, IProject['backgroundBlurHash'] | null],
+               async ([projectId, blurHash], oldValue) => {
+                       const projectValue = toValue(project)
 			if (
 				projectValue === null ||
 				!projectValue.backgroundInformation ||

--- a/frontend/src/composables/useRenewTokenOnFocus.ts
+++ b/frontend/src/composables/useRenewTokenOnFocus.ts
@@ -11,7 +11,7 @@ export function useRenewTokenOnFocus() {
 	const router = useRouter()
 	const authStore = useAuthStore()
 
-	const userInfo = computed(() => authStore.info)
+       const userInfo = computed(() => authStore.info.value)
 	const authenticated = computed(() => authStore.authenticated)
 
 	// Try renewing the token every time vikunja is loaded initially
@@ -25,9 +25,9 @@ export function useRenewTokenOnFocus() {
 		}
 
 		const nowInSeconds = new Date().getTime() / MILLISECONDS_A_SECOND
-		const expiresIn = userInfo.value !== null
-			? userInfo.value.exp - nowInSeconds
-			: 0
+       const expiresIn = userInfo.value
+               ? userInfo.value.exp - nowInSeconds
+               : 0
 
 		// If the token expiry is negative, it is already expired and we have no choice but to redirect
 		// the user to the login page

--- a/frontend/src/composables/useRouteWithModal.ts
+++ b/frontend/src/composables/useRouteWithModal.ts
@@ -6,7 +6,7 @@ import {useProjectStore} from '@/stores/projects'
 export function useRouteWithModal() {
 	const router = useRouter()
 	const route = useRoute()
-	const backdropView = computed(() => route.fullPath && window.history.state.backdropView)
+       const backdropView = computed(() => route.fullPath ? window.history.state.backdropView : undefined)
 	const baseStore = useBaseStore()
 	const projectStore = useProjectStore()
 
@@ -55,7 +55,7 @@ export function useRouteWithModal() {
 		currentModal.value = h(component, routeProps)
 	})
 
-	const historyState = computed(() => route.fullPath && window.history.state)
+       const historyState = computed(() => route.fullPath ? window.history.state : undefined)
 
 	function closeModal() {
 
@@ -63,8 +63,10 @@ export function useRouteWithModal() {
 		// we need to reflect that change in the route when they close the task modal.
 		// The last route is only available as resolved string, therefore we need to use a regex for matching here
 		const routeMatch = new RegExp('\\/projects\\/\\d+\\/(\\d+)', 'g')
-		const match = routeMatch.exec(historyState.value.back)
-		if (match !== null && baseStore.currentProject) {
+               const match = historyState.value?.back
+                       ? routeMatch.exec(historyState.value.back)
+                       : null
+               if (match !== null && baseStore.currentProject) {
 			let viewId: string | number = match[1]
 
 			if (!viewId) {
@@ -82,12 +84,14 @@ export function useRouteWithModal() {
 			return
 		}
 
-		if (historyState.value) {
-			router.back()
-		} else {
-			const backdropRoute = historyState.value?.backdropView && router.resolve(historyState.value.backdropView)
-			router.push(backdropRoute)
-		}
+               if (historyState.value) {
+                       router.back()
+               } else {
+                       const backdropRoute = historyState.value?.backdropView && router.resolve(historyState.value.backdropView)
+                       if (backdropRoute) {
+                               router.push(backdropRoute)
+                       }
+               }
 	}
 
 	return {routeWithModal, currentModal, closeModal}


### PR DESCRIPTION
## Summary
- guard null access in project background composable
- fix user info computed in renew token composable
- avoid undefined history state access in route with modal

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: "Argument of type '{}' is not assignable to parameter of type ...")*

------
https://chatgpt.com/codex/tasks/task_e_684945601558832081081fabf7d9852d