### PR TITLE
Fix transactions in tests and update tasks

### DIFF
--- a/pkg/models/tasks.go
+++ b/pkg/models/tasks.go
@@ -1256,7 +1256,7 @@ func (t *Task) Update(s *xorm.Session, a web.Auth) (err error) {
 
 	_, err = s.ID(t.ID).
 		Cols(colsToUpdate...).
-		Update(ot)
+		Update(&ot)
 	*t = ot
 	if err != nil {
 		return err

--- a/pkg/models/tasks_test.go
+++ b/pkg/models/tasks_test.go
@@ -38,10 +38,10 @@ func TestTask_Create(t *testing.T) {
 
 	// We only test creating a task here, the rights are all well tested in the integration tests.
 
+	db.LoadAndAssertFixtures(t)
+
 	t.Run("normal", func(t *testing.T) {
-		db.LoadAndAssertFixtures(t)
-		s := db.NewSession()
-		defer s.Close()
+		s := db.BeginTx(t)
 
 		task := &Task{
 			Title:       "Lorem",
@@ -55,17 +55,14 @@ func TestTask_Create(t *testing.T) {
 		// Assert getting a new index
 		assert.NotEmpty(t, task.Index)
 		assert.Equal(t, int64(18), task.Index)
-		err = s.Commit()
-		require.NoError(t, err)
-
-		db.AssertExists(t, "tasks", map[string]interface{}{
+		db.AssertExistsTx(t, s, "tasks", map[string]interface{}{
 			"id":            task.ID,
 			"title":         "Lorem",
 			"description":   "Lorem Ipsum Dolor",
 			"project_id":    1,
 			"created_by_id": 1,
 		}, false)
-		db.AssertExists(t, "task_buckets", map[string]interface{}{
+		db.AssertExistsTx(t, s, "task_buckets", map[string]interface{}{
 			"task_id":   task.ID,
 			"bucket_id": 1,
 		}, false)
@@ -73,9 +70,7 @@ func TestTask_Create(t *testing.T) {
 		events.AssertDispatched(t, &TaskCreatedEvent{})
 	})
 	t.Run("with reminders", func(t *testing.T) {
-		db.LoadAndAssertFixtures(t)
-		s := db.NewSession()
-		defer s.Close()
+		s := db.BeginTx(t)
 
 		task := &Task{
 			Title:       "Lorem",
@@ -111,8 +106,13 @@ func TestTask_Create(t *testing.T) {
 		assert.Equal(t, time.Date(2023, time.March, 7, 22, 5, 19, 0, time.UTC), task.Reminders[2].Reminder)
 		assert.Equal(t, ReminderRelationEndDate, task.Reminders[2].RelativeTo)
 		assert.Equal(t, time.Date(2023, time.March, 7, 23, 0, 0, 0, time.UTC), task.Reminders[3].Reminder)
-		err = s.Commit()
-		require.NoError(t, err)
+
+		db.AssertExistsTx(t, s, "tasks", map[string]interface{}{
+			"id":          task.ID,
+			"project_id":  1,
+			"title":       "Lorem",
+			"description": "Lorem Ipsum Dolor",
+		}, false)
 	})
 	t.Run("empty title", func(t *testing.T) {
 		db.LoadAndAssertFixtures(t)


### PR DESCRIPTION
## Summary
- add BeginTx helper for transactional tests
- add `Assert*Tx` helpers for asserting inside transactions
- fix `Task.Update` to use pointer preventing xorm panic
- demo new helper in Task_Create tests

## Testing
- `mage test:unit`

------
https://chatgpt.com/codex/tasks/task_e_684943338b208320871859ab9e0e5b4d