### PR TITLE
Add basic cookie consent banner

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -16,6 +16,7 @@
 		
 		<Teleport to="body">
 			<AddToHomeScreen />
+			<CookieBanner />
 			<UpdateNotification />
 			<Notification />
 			<DemoMode />
@@ -47,6 +48,7 @@ import {useBaseStore} from '@/stores/base'
 import {useColorScheme} from '@/composables/useColorScheme'
 import {useBodyClass} from '@/composables/useBodyClass'
 import AddToHomeScreen from '@/components/home/AddToHomeScreen.vue'
+import CookieBanner from '@/components/misc/CookieBanner.vue'
 import DemoMode from '@/components/home/DemoMode.vue'
 
 const importAccountDeleteService = () => import('@/services/accountDelete')

--- a/frontend/src/components/misc/CookieBanner.vue
+++ b/frontend/src/components/misc/CookieBanner.vue
@@ -1,0 +1,67 @@
+<template>
+	<div
+		v-if="showBanner"
+		class="cookie-banner"
+	>
+		<p class="message">
+			{{ $t('cookieBanner.message') }}
+		</p>
+		<div class="buttons">
+			<BaseButton
+				variant="primary"
+				@click="acceptAll"
+			>
+				{{ $t('cookieBanner.accept') }}
+			</BaseButton>
+			<BaseButton
+				variant="secondary"
+				@click="rejectAll"
+			>
+				{{ $t('cookieBanner.reject') }}
+			</BaseButton>
+		</div>
+	</div>
+</template>
+
+<script lang="ts" setup>
+import {computed} from 'vue'
+import {useLocalStorage} from '@vueuse/core'
+import BaseButton from '@/components/base/BaseButton.vue'
+
+const consent = useLocalStorage<'accepted' | 'rejected' | null>('cookieConsent', null)
+
+const showBanner = computed(() => consent.value === null)
+
+function acceptAll() {
+    consent.value = 'accepted'
+}
+
+function rejectAll() {
+    consent.value = 'rejected'
+}
+</script>
+
+<style lang="scss" scoped>
+.cookie-banner {
+    position: fixed;
+    bottom: 1rem;
+    inset-inline: 1rem;
+    max-width: max-content;
+    margin-inline: auto;
+    padding: .5rem 1rem;
+    background: var(--grey-900);
+    border-radius: $radius;
+    color: var(--grey-200);
+    z-index: 5000;
+
+    display: flex;
+    flex-direction: column;
+    gap: .5rem;
+
+    .buttons {
+        display: flex;
+        gap: .5rem;
+        justify-content: center;
+    }
+}
+</style>

--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -31,6 +31,11 @@
     "title": "You are offline.",
     "text": "Please check your network connection and try again."
   },
+  "cookieBanner": {
+    "message": "We use cookies to enhance your experience.",
+    "accept": "Accept all",
+    "reject": "Reject all"
+  },
   "user": {
     "auth": {
       "username": "Username",


### PR DESCRIPTION
## Summary
- add a simple cookie banner component with accept/reject actions
- show the cookie banner in the app root
- provide English translations for the banner

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: "Argument of type" and similar errors)*
- `pnpm test:unit -- --run`
- `VIKUNJA_SERVICE_ROOTPATH=$(pwd) mage test:unit`
- `VIKUNJA_SERVICE_ROOTPATH=$(pwd) mage test:integration`
- `mage check:translations`


------
https://chatgpt.com/codex/tasks/task_e_6849a8c6d2e48320b3c8d19d0e28799b