### PR TITLE
Respect reduced motion preference

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ These instructions summarize the development guidelines from the official Vikunj
 - Respect the formatting rules from `.editorconfig` in the repository root and all subfolders.
 - The root `.editorconfig` covers the entire repository, including the frontend.
 - When changing frontend code adhere to the ESLint rules defined in `frontend/eslint.config.js`. Run `pnpm lint` (or `pnpm lint:fix`) to check and automatically fix issues.
+- Wrap style transitions in `@media (prefers-reduced-motion: no-preference)` blocks and provide instant fallbacks for users who prefer reduced motion.
 
 # Building
 

--- a/frontend/src/styles/transitions.scss
+++ b/frontend/src/styles/transitions.scss
@@ -1,16 +1,27 @@
-.fade-enter-active,
-.fade-leave-active {
-  transition: opacity $transition-duration;
+@media (prefers-reduced-motion: no-preference) {
+  .fade-enter-active,
+  .fade-leave-active {
+    transition: opacity $transition-duration;
+  }
+
+  .width-enter-active,
+  .width-leave-active {
+    transition: width $transition-duration;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-enter-active,
+  .fade-leave-active,
+  .width-enter-active,
+  .width-leave-active {
+    transition-duration: 1ms;
+  }
 }
 
 .fade-enter-from,
 .fade-leave-to {
   opacity: 0;
-}
-
-.width-enter-active,
-.width-leave-active {
-  transition: width $transition-duration;
 }
 
 .width-enter-from,


### PR DESCRIPTION
## Summary
- wrap existing transition rules in a reduced-motion media query
- fall back to instant transitions when users prefer reduced motion
- document reduced-motion rule in AGENTS

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Parameter 'model' implicitly has an 'any' type, etc.)*
- `pnpm test:unit --run`


------
https://chatgpt.com/codex/tasks/task_e_684a7376bef483208ee91a8a18a50296