### PR TITLE
Add dark mode colors for code blocks

### DIFF
--- a/frontend/src/styles/theme/content.scss
+++ b/frontend/src/styles/theme/content.scss
@@ -28,3 +28,8 @@
   background-color: var(--grey-200);
   border-left: .25rem solid var(--grey-300);
 }
+
+.dark code {
+  background-color: var(--code-background);
+  color: var(--code);
+}


### PR DESCRIPTION
## Summary
- style `<code>` blocks for dark mode

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Cannot find name 'ImportMetaEnv', etc.)*
- `pnpm vitest --run`


------
https://chatgpt.com/codex/tasks/task_e_684a76c3ddb083209a38a5b857cd9a49