### PR TITLE
Add skeleton loading rows to gantt view

### DIFF
--- a/frontend/src/styles/components/_index.scss
+++ b/frontend/src/styles/components/_index.scss
@@ -2,3 +2,4 @@
 @import "labels";
 @import "task";
 @import "tasks";
+@import "project-gantt";

--- a/frontend/src/styles/components/project-gantt.scss
+++ b/frontend/src/styles/components/project-gantt.scss
@@ -1,0 +1,29 @@
+.gantt-skeleton-rows {
+    padding: 1rem;
+    list-style: none;
+
+    .gantt-skeleton-row {
+        height: 1.5rem;
+        margin-bottom: .5rem;
+        border-radius: $radius;
+        background: var(--grey-200);
+        position: relative;
+        overflow: hidden;
+
+        &::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: -100%;
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(90deg, transparent, hsla(var(--white-hsl), 0.6), transparent);
+            animation: gantt-skeleton-loading 1s infinite;
+        }
+    }
+}
+
+@keyframes gantt-skeleton-loading {
+    from { left: -100%; }
+    to { left: 100%; }
+}


### PR DESCRIPTION
## Summary
- add a `loading` prop to `ProjectGantt.vue`
- show skeleton rows while data loads
- style skeletons in new `project-gantt.scss`

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: various TS errors)*
- `pnpm test:unit` *(fails: Command failed with exit code 130)*

------
https://chatgpt.com/codex/tasks/task_e_684a7722f3dc83209a3e955eec441ea4