### PR TITLE
Add text-wrap balance to headings

### DIFF
--- a/frontend/src/styles/theme/_index.scss
+++ b/frontend/src/styles/theme/_index.scss
@@ -8,5 +8,6 @@
 @import "link-share";
 @import "loading";
 @import "flatpickr";
+@import "typography";
 @import 'helpers';
 @import 'navigation';

--- a/frontend/src/styles/theme/typography.scss
+++ b/frontend/src/styles/theme/typography.scss
@@ -1,0 +1,8 @@
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  text-wrap: balance;
+}


### PR DESCRIPTION
## Summary
- add typography.scss with text-wrap balance on heading tags
- include typography.scss in theme styles

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Argument of type '{}' is not assignable to parameter of type ...)*
- `pnpm test:unit -- --run`
- `mage test:unit`
- `mage test:integration`


------
https://chatgpt.com/codex/tasks/task_e_684a76bc3f8c83209f378a7fd7bb403b