### PR TITLE
Add reload checklist persistence test

### DIFF
--- a/frontend/cypress/e2e/task/task.spec.ts
+++ b/frontend/cypress/e2e/task/task.spec.ts
@@ -911,10 +911,10 @@ describe('Task', () => {
 				.should('exist')
 		})
 
-		it('Can check items off a checklist', () => {
-			const tasks = TaskFactory.create(1, {
-				id: 1,
-				description: `
+                it('Can check items off a checklist', () => {
+                        const tasks = TaskFactory.create(1, {
+                                id: 1,
+                                description: `
 <ul data-type="taskList">
 	<li data-checked="false" data-type="taskItem"><label><input type="checkbox"><span></span></label>
 		<div><p>First Item</p></div>
@@ -949,9 +949,46 @@ describe('Task', () => {
 				.should('be.checked')
 			cy.get('.tiptap__editor input[type=checkbox]')
 				.should('have.length', 5)
-			cy.get('.task-view .checklist-summary')
-				.should('contain.text', '2 of 5 tasks')
-		})
+                        cy.get('.task-view .checklist-summary')
+                                .should('contain.text', '2 of 5 tasks')
+                })
+
+                it('Persists checked checklist items after reload', () => {
+                        const tasks = TaskFactory.create(1, {
+                                id: 1,
+                                description: `
+<ul data-type="taskList">
+        <li data-checked="false" data-type="taskItem"><label><input type="checkbox"><span></span></label>
+                <div><p>First Item</p></div>
+        </li>
+        <li data-checked="false" data-type="taskItem"><label><input type="checkbox"><span></span></label>
+                <div><p>Second Item</p></div>
+        </li>
+</ul>`,
+                        })
+                        cy.visit(`/tasks/${tasks[0].id}`)
+
+                        cy.get('.task-view .checklist-summary')
+                                .should('contain.text', '0 of 2 tasks')
+                        cy.get('.tiptap__editor ul > li input[type=checkbox]')
+                                .first()
+                                .click()
+
+                        cy.get('.task-view .details.content.description h3 span.is-small.has-text-success')
+                                .contains('Saved!')
+                                .should('exist')
+
+                        cy.get('.task-view .checklist-summary')
+                                .should('contain.text', '1 of 2 tasks')
+
+                        cy.reload()
+
+                        cy.get('.task-view .checklist-summary')
+                                .should('contain.text', '1 of 2 tasks')
+                        cy.get('.tiptap__editor ul > li input[type=checkbox]')
+                                .first()
+                                .should('be.checked')
+                })
 
 		it('Should use the editor to render description', () => {
 			const tasks = TaskFactory.create(1, {


### PR DESCRIPTION
## Summary
- ensure checked checklist items remain saved after a page reload

## Testing
- `pnpm test:unit`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_684b44a17bc08320a510793c590aad74