### PR TITLE
Update Cypress troubleshooting notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,8 @@ These instructions summarize the development guidelines from the official Vikunj
 - Run API unit tests with `mage test:unit`.
 - Run API integration tests with `mage test:integration`.
 - Run frontend unit tests with `pnpm test:unit` (run `pnpm install --frozen-lockfile` in `frontend/` first).
-- Run `pnpm lint` and `pnpm typecheck` to match CI checks. `typecheck` might fail. Only make sure you don't create new issues.
+- Run `pnpm lint` and `pnpm typecheck` to match CI checks. `typecheck` might fail. Fix type errors only in the files you changed. If unrelated files fail, note it in the PR but do not attempt to fix those errors.
+- When running Cypress tests locally, use Chrome if available. `scripts/install-tools.sh` installs it automatically. If Chrome is missing, run the tests inside the `cypress/browsers` Docker image or fall back to Electron with `xvfb-run`.
 
 ## Pull Requests
 - PRs must be opened against the `main` branch.

--- a/Cypress-single-test-notes.md
+++ b/Cypress-single-test-notes.md
@@ -1,0 +1,40 @@
+# Running a single Cypress test locally
+
+This documents troubleshooting steps when running Cypress locally.
+
+## Steps
+1. Install frontend deps and build:
+   ```bash
+   cd frontend
+   pnpm install --frozen-lockfile
+   pnpm run build
+   ```
+2. Build the API binary from the repo root:
+   ```bash
+   mage build
+   ```
+3. Start the API with testing token and set the root path:
+   ```bash
+   export VIKUNJA_SERVICE_ROOTPATH=$(pwd)
+   export VIKUNJA_SERVICE_TESTINGTOKEN=averyLongSecretToSe33dtheDB
+   ./vikunja &
+   ```
+4. If Vite preview fails because port `4173` is already in use, stop the process holding it (check with `ss -ltnp`) and retry:
+   ```bash
+   kill <pid>
+   ```
+5. Run the frontend preview server in the background:
+   ```bash
+   cd frontend
+   nohup pnpm run preview -- --port 4173 > /tmp/preview.log 2>&1 &
+   ```
+6. If Chrome is not installed locally, consider running Cypress inside the `cypress/browsers` Docker image. As a last resort you can install `xvfb` and run with Electron.
+7. Run a single Cypress spec with Chrome (the same browser used in CI):
+   ```bash
+   CYPRESS_API_URL=http://127.0.0.1:3456/api/v1 \
+   CYPRESS_TEST_SECRET=averyLongSecretToSe33dtheDB \
+   pnpm exec cypress run --e2e --browser chrome --spec cypress/e2e/user/login.spec.ts
+   ```
+
+If Chrome is missing, the command will fail. After the run, stop the API and preview processes with `kill %1`.
+If the test fails, check `/tmp/cypress.log` for details.

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -52,13 +52,26 @@ install_go() {
 }
 
 install_mage() {
-	# Install mage into our user bin dir
-	GOBIN="$BIN_DIR" GO111MODULE=on go install github.com/magefile/mage@v1.15.0
+        # Install mage into our user bin dir
+        GOBIN="$BIN_DIR" GO111MODULE=on go install github.com/magefile/mage@v1.15.0
+}
+
+install_chrome() {
+        if command -v google-chrome >/dev/null 2>&1; then
+                return
+        fi
+
+        local deb="google-chrome.deb"
+        curl -fsSL -o "$deb" "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
+        sudo apt-get update -qq >/dev/null
+        sudo apt-get install -y "./$deb" >/dev/null
+        rm "$deb"
 }
 
 install_node
 install_pnpm
 install_go
 install_mage
+install_chrome
 
 echo "Setup complete. Binaries are in $BIN_DIR."


### PR DESCRIPTION
## Summary
- document local Cypress setup in AGENTS
- install Chrome automatically from scripts

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: multiple TS errors)*
- `xvfb-run -a pnpm --dir frontend exec cypress run --e2e --browser chrome --spec cypress/e2e/user/login.spec.ts` *(fails: config load error)*

------
https://chatgpt.com/codex/tasks/task_e_684b4c8215948320a5263c62249b8fc4