### PR TITLE
Add act workflow docs and helper

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,3 @@
+-P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest
+--secret-file=.github/act.secrets
+

--- a/.github/act.secrets.example
+++ b/.github/act.secrets.example
@@ -1,0 +1,6 @@
+# Example secrets for running act locally
+# Copy this file to .github/act.secrets and fill in values as needed
+DOCKER_HUB_USERNAME=your-docker-user
+DOCKER_HUB_PASSWORD=your-docker-pass
+CYPRESS_RECORD_KEY=your-cypress-key
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,6 @@
 # Contribution Guidelines
 
 Please check out the guidelines on https://vikunja.io/docs/development/
+
+For instructions on testing workflows locally with `act`, see [docs/act.md](docs/act.md).
+

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ try it on [try.vikunja.io](https://try.vikunja.io)!
 * [Development setup](https://vikunja.io/docs/development/)
 * [Magefile](https://vikunja.io/docs/magefile/)
 * [Testing](https://vikunja.io/docs/testing/)
+* [Run GitHub Actions locally](docs/act.md)
 
 All docs can be found on [the Vikunja home page](https://vikunja.io/docs/).
 

--- a/docs/act.md
+++ b/docs/act.md
@@ -1,0 +1,36 @@
+# Running GitHub workflows locally with act
+
+The [act](https://github.com/nektos/act) tool can execute GitHub Actions in Docker containers.
+This makes it possible to test workflows without pushing changes.
+
+## Installation
+
+Download a prebuilt binary from the [act releases](https://github.com/nektos/act/releases) page
+or use a package manager such as Homebrew:
+
+```bash
+brew install act
+```
+
+## Usage
+
+Pull the default platform image and run a workflow:
+
+```bash
+docker pull ghcr.io/catthehacker/ubuntu:act-latest
+act pull_request
+```
+
+The repository provides an [`.actrc`](../.actrc) file so `act` uses the same base image as CI.
+Secrets used in the workflows can be stored in `.github/act.secrets`. Copy
+`.github/act.secrets.example` as a starting point and adjust the values.
+To trigger other events, pass them as arguments, for example:
+
+```bash
+act push --eventpath .github/event.json
+```
+
+Some jobs require additional services like PostgreSQL, MySQL or a Chrome browser.
+You can start these services with Docker before running `act`.
+The `scripts/run-act.sh` helper installs all required tools and then invokes `act`.
+

--- a/scripts/run-act.sh
+++ b/scripts/run-act.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! command -v act >/dev/null 2>&1; then
+    echo "act is required. Install it from https://github.com/nektos/act/releases" >&2
+    exit 1
+fi
+
+# Install repo prerequisites if missing
+"$SCRIPT_DIR/install-tools.sh" >/dev/null
+
+docker pull ghcr.io/catthehacker/ubuntu:act-latest >/dev/null
+
+act "$@"
+


### PR DESCRIPTION
## Summary
- document how to run GitHub Actions locally with `act`
- add `.actrc` default config and secrets template
- provide `scripts/run-act.sh` helper
- link the new guide from README and CONTRIBUTING

## Testing
- `mage lint`


------
https://chatgpt.com/codex/tasks/task_e_684eff3f4db8832098b2cadda908ca94