### PR TITLE
Fix bulma vendor path and SCSS imports

### DIFF
--- a/frontend/src/styles/common-imports.scss
+++ b/frontend/src/styles/common-imports.scss
@@ -11,7 +11,8 @@
 //
 
 // forwards from "bulma-css-variables/sass/utilities/_all";
-@forward "bulma-css-variables/sass/utilities/initial-variables.scss" with (
+@use "sass:math";
+@forward "bulma-css-variables/sass/utilities/initial-variables.sass" with (
   $family-sans-serif: "'Open Sans', Helvetica, Arial, sans-serif"
 );
 @forward "bulma-css-variables/sass/utilities/functions";
@@ -22,7 +23,7 @@
 @forward "bulma-css-variables/sass/utilities/extends";
 
 
-@use "bulma-css-variables/sass/utilities/initial-variables.scss" as *;
+@use "bulma-css-variables/sass/utilities/initial-variables.sass" as *;
 
 // since $tablet is defined by bulma we can just define it after importing the utilities
 $mobile: math.div($tablet, 2);

--- a/frontend/src/styles/components/tasks.scss
+++ b/frontend/src/styles/components/tasks.scss
@@ -1,3 +1,5 @@
+@use "../common-imports.scss" as *;
+
 // FIXME: These classes are used all over.
 // very hard to untangle
 // they have many overwrites at different positions

--- a/frontend/src/styles/theme/background.scss
+++ b/frontend/src/styles/theme/background.scss
@@ -1,3 +1,5 @@
+@use "../common-imports.scss" as *;
+
 .app-container.has-background,
 .link-share-container.has-background {
   position: relative;

--- a/frontend/src/styles/theme/link-share.scss
+++ b/frontend/src/styles/theme/link-share.scss
@@ -1,3 +1,5 @@
+@use "../common-imports.scss" as *;
+
 .field.has-addons.no-input-mobile {
   .control:first-child {
     width: 100%;

--- a/frontend/src/styles/theme/navigation.scss
+++ b/frontend/src/styles/theme/navigation.scss
@@ -1,3 +1,5 @@
+@use "../common-imports.scss" as *;
+
 // these are general menu styles
 // should be in own components
 .menu {

--- a/frontend/src/styles/transitions.scss
+++ b/frontend/src/styles/transitions.scss
@@ -1,3 +1,5 @@
+@use "./common-imports.scss" as *;
+
 .fade-enter-active,
 .fade-leave-active {
   transition: opacity $transition-duration;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -22,7 +22,7 @@ const pathBulma = resolve(dirname(pathSrc), 'vendor/bulma-css-variables')
 
 // the @use rules have to be the first in the compiled stylesheets
 const PREFIXED_SCSS_STYLES = `@use "sass:math";
-@use "${pathSrc}/styles/common-imports.scss";`
+@use "${pathSrc}/styles/common-imports.scss" as *;`
 
 /*
 ** Configure sentry plugin


### PR DESCRIPTION
## Summary
- load bulma variables from `.sass` sources
- expose math helpers for SCSS
- preload common styles in tasks and theme scss files
- pass styles globally for Vite builds

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Cannot find name 'Ref' in `General.vue`)*
- `pnpm test:unit`
- `pnpm run build` *(fails: Undefined variable in `generic.sass`)*

------
https://chatgpt.com/codex/tasks/task_e_684f25cd935c8320ad4f086461eb33b4