### PR TITLE
Add Storybook support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ devenv.local.nix
 
 # pre-commit
 .pre-commit-config.yaml
+
+*storybook.log
+storybook-static

--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -1,0 +1,16 @@
+import type { StorybookConfig } from '@storybook/vue3';
+
+const config: StorybookConfig = {
+  stories: [
+    '../src/**/*.stories.@(ts|js|vue)'
+  ],
+  addons: [
+    '@storybook/addon-actions',
+    '@storybook/addon-links'
+  ],
+  framework: {
+    name: '@storybook/vue3-vite',
+    options: {}
+  }
+};
+export default config;

--- a/frontend/.storybook/preview.ts
+++ b/frontend/.storybook/preview.ts
@@ -1,0 +1,15 @@
+import type { Preview } from '@storybook/vue3'
+import '../src/storybook.setup'
+
+const preview: Preview = {
+  parameters: {
+    controls: {
+      matchers: {
+       color: /(background|color)$/i,
+       date: /Date$/i,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -49,3 +49,17 @@ pnpm run build
 ```shell
 pnpm run lint
 ```
+
+### Storybook
+
+Storybook can be used to preview and test components.
+
+```shell
+pnpm storybook
+```
+
+The static build can be created with:
+
+```shell
+pnpm storybook:build
+```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,9 @@
     "fonts:subset": "./scripts/fonts-subset.sh",
     "story:dev": "histoire dev",
     "story:build": "histoire build",
-    "story:preview": "histoire preview"
+    "story:preview": "histoire preview",
+    "storybook": "storybook dev -p 6006",
+    "storybook:build": "storybook build"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "6.7.2",
@@ -114,6 +116,9 @@
     "@faker-js/faker": "9.8.0",
     "@histoire/plugin-screenshot": "1.0.0-alpha.2",
     "@histoire/plugin-vue": "1.0.0-alpha.2",
+    "@storybook/addon-actions": "^9.0.8",
+    "@storybook/addon-links": "^9.0.10",
+    "@storybook/vue3": "^9.0.10",
     "@tsconfig/node22": "22.0.2",
     "@types/codemirror": "5.60.15",
     "@types/is-touch-device": "1.0.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -212,6 +212,15 @@ importers:
       '@histoire/plugin-vue':
         specifier: 1.0.0-alpha.2
         version: 1.0.0-alpha.2(histoire@1.0.0-alpha.2(@types/node@22.15.24)(sass-embedded@1.89.0)(sass@1.80.6)(terser@5.31.6)(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(sass-embedded@1.89.0)(sass@1.80.6)(terser@5.31.6)(yaml@2.5.0)))(vite@6.3.5(@types/node@22.15.24)(jiti@2.4.2)(sass-embedded@1.89.0)(sass@1.80.6)(terser@5.31.6)(yaml@2.5.0))(vue@3.5.16(typescript@5.8.3))
+      '@storybook/addon-actions':
+        specifier: ^9.0.8
+        version: 9.0.8
+      '@storybook/addon-links':
+        specifier: ^9.0.10
+        version: 9.0.10(storybook@9.0.10(@testing-library/dom@10.4.0))
+      '@storybook/vue3':
+        specifier: ^9.0.10
+        version: 9.0.10(storybook@9.0.10(@testing-library/dom@10.4.0))(vue@3.5.16(typescript@5.8.3))
       '@tsconfig/node22':
         specifier: 22.0.2
         version: 22.0.2
@@ -336,6 +345,9 @@ packages:
     resolution: {integrity: sha512-r6/Um+GLidi9mFTx8qiFf1ECMNmwLTLp+CgKVLpYZvJ2aV6mYoe1Uv8Iq1AwqRhhIAdf04aFJ0xzGEO1gnOm1g==}
     peerDependencies:
       cypress: 2 - 14
+
+  '@adobe/css-tools@4.4.3':
+    resolution: {integrity: sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==}
 
   '@akryum/tinypool@0.3.1':
     resolution: {integrity: sha512-nznEC1ZA/m3hQDEnrGQ4c5gkaa9pcaVnw4LFJyzBAaR7E3nfiAPEHS3otnSafpZouVnoKeITl5D+2LsnwlnK8g==}
@@ -2205,12 +2217,48 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@storybook/addon-actions@9.0.8':
+    resolution: {integrity: sha512-LFePu7PPnWN0Il/uoUpmA5T0J0C7d6haJIbg0pXrjxW2MQVSYXE4S4LSUz8fOImltBDV3xAl6tLPYHFj6VcrOA==}
+
+  '@storybook/addon-links@9.0.10':
+    resolution: {integrity: sha512-is7I8ZnFF06npQQamQEMzVw+8UZT3QqYeOhMP8AQwKEFNn0LSvq5+Q6EHzQmY7VK9RWOv/xUrblaRhZe3A0W6A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      storybook: ^9.0.10
+    peerDependenciesMeta:
+      react:
+        optional: true
+
+  '@storybook/global@5.0.0':
+    resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
+
+  '@storybook/vue3@9.0.10':
+    resolution: {integrity: sha512-4IktJjSXclR1nHainXSVaqE+fgxPWwX7ey5tWsmGzEPpEcopvu3PYazOVbrh/xEA9/dBPO7v6a+C1dssa8K9Ug==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      storybook: ^9.0.10
+      vue: ^3.0.0
+
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     resolution: {integrity: sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==}
 
   '@szmarczak/http-timer@1.1.2':
     resolution: {integrity: sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==}
     engines: {node: '>=6'}
+
+  '@testing-library/dom@10.4.0':
+    resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.6.3':
+    resolution: {integrity: sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@tiptap/core@2.13.0':
     resolution: {integrity: sha512-VDwlf5+DznkrAT+vlggl9t/mPVeo3ayi4irXgLPkDfHAY8adVIx+RCek6GBChclJ8q2Iy0HZwpIYs/8L7tadqA==}
@@ -2425,6 +2473,9 @@ packages:
 
   '@tsconfig/node22@22.0.2':
     resolution: {integrity: sha512-Kmwj4u8sDRDrMYRoN9FDEcXD8UpBSaPQQ24Gz+Gamqfm7xxn+GBR7ge/Z7pK8OXNGyUzbSwJj+TH6B+DS/epyA==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/codemirror@5.60.15':
     resolution: {integrity: sha512-dTOvwEQ+ouKJ/rE9LT1Ue2hmP6H1mZv5+CCnNWu2qtiOe2LQa9lCprEY20HxiDmV/Bxh+dXjywmy5aKvoGjULA==}
@@ -2646,6 +2697,9 @@ packages:
       vite: ^5.0.0 || ^6.0.0
       vue: ^3.2.25
 
+  '@vitest/expect@3.0.9':
+    resolution: {integrity: sha512-5eCqRItYgIML7NNVgJj6TVCmdzE7ZVgJhruW0ziSQV4V7PvLkDL1bBkBdcTs/VuIz0IxPb5da1IDSqc1TR9eig==}
+
   '@vitest/expect@3.1.4':
     resolution: {integrity: sha512-xkD/ljeliyaClDYqHPNCiJ0plY5YIcM0OlRiZizLhlPmpXWpxnGMyTZXOHFhFeG7w9P5PBeL4IdtJ/HeQwTbQA==}
 
@@ -2660,6 +2714,9 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@3.0.9':
+    resolution: {integrity: sha512-OW9F8t2J3AwFEwENg3yMyKWweF7oRJlMyHOMIhO5F3n0+cgQAJZBjNgrF8dLwFTEXl5jUqBLXd9QyyKv8zEcmA==}
+
   '@vitest/pretty-format@3.1.4':
     resolution: {integrity: sha512-cqv9H9GvAEoTaoq+cYqUTCGscUjKqlJZC7PRwY5FMySVj5J+xOm1KQcCiYHJOEzOKRUhLH4R2pTwvFlWCEScsg==}
 
@@ -2669,8 +2726,14 @@ packages:
   '@vitest/snapshot@3.1.4':
     resolution: {integrity: sha512-JPHf68DvuO7vilmvwdPr9TS0SuuIzHvxeaCkxYcCD4jTk67XwL45ZhEHFKIuCm8CYstgI6LZ4XbwD6ANrwMpFg==}
 
+  '@vitest/spy@3.0.9':
+    resolution: {integrity: sha512-/CcK2UDl0aQ2wtkp3YVWldrpLRNCfVcIOFGlVGKO4R5eajsH393Z1yiXLVQ7vWsj26JOEjeZI0x5sm5P4OGUNQ==}
+
   '@vitest/spy@3.1.4':
     resolution: {integrity: sha512-Xg1bXhu+vtPXIodYN369M86K8shGLouNjoVI78g8iAq2rFoHFdajNvJJ5A/9bPMFcfQqdaCpOgWKEoMQg/s0Yg==}
+
+  '@vitest/utils@3.0.9':
+    resolution: {integrity: sha512-ilHM5fHhZ89MCp5aAaM9uhfl1c2JdxVxl3McqsdVyVNN6JffnEen8UMCdRTzOhGXNQGo5GNL9QugHrz727Wnng==}
 
   '@vitest/utils@3.1.4':
     resolution: {integrity: sha512-yriMuO1cfFhmiGc8ataN51+9ooHRuURdfAZfwFd3usWynjzpLslZdYnRegTv32qdgtJTsj15FoeZe2g15fY1gg==}
@@ -2892,6 +2955,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
@@ -2914,6 +2981,13 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   array-buffer-byte-length@1.0.1:
     resolution: {integrity: sha512-ahC5W1xgou+KTXix4sAO8Ki12Q+jf4i0+tmk3sC+zgcynshkHxzpXdImBehiUYKKKDwvfFiJl1tZt6ewscS1Mg==}
@@ -2940,6 +3014,10 @@ packages:
 
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
+
+  ast-types@0.16.1:
+    resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
 
   astral-regex@2.0.0:
@@ -3036,6 +3114,10 @@ packages:
 
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
+
+  better-opn@3.0.2:
+    resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
+    engines: {node: '>=12.0.0'}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -3388,6 +3470,9 @@ packages:
     resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
     engines: {node: '>= 6'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssdb@8.3.0:
     resolution: {integrity: sha512-c7bmItIg38DgGjSwDPZOYF/2o0QU/sSgkWOMyl8votOfgFuyiFKWPesmCGEsrGLxEA9uL540cp8LdaGEjUGsZQ==}
 
@@ -3574,6 +3659,12 @@ packages:
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
   dom-serializer@1.4.1:
     resolution: {integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==}
 
@@ -3708,6 +3799,11 @@ packages:
   es-to-primitive@1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==}
     engines: {node: '>= 0.4'}
+
+  esbuild-register@3.6.0:
+    resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
+    peerDependencies:
+      esbuild: '>=0.12 <1'
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -4715,6 +4811,10 @@ packages:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
 
@@ -5402,6 +5502,10 @@ packages:
     resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-ms@9.2.0:
     resolution: {integrity: sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==}
     engines: {node: '>=18'}
@@ -5535,6 +5639,9 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
@@ -5557,6 +5664,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  recast@0.23.11:
+    resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
+    engines: {node: '>= 4'}
 
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -6025,6 +6136,15 @@ packages:
   std-env@3.9.0:
     resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
+  storybook@9.0.10:
+    resolution: {integrity: sha512-wDelDvr1AnlaE8ZZwap9rwOgYBX/kWwX/LTFWWhQKkXxPp/OdRlNIL/0YmUFe8ANiXk5E6MuevW94zW3q5rTqw==}
+    hasBin: true
+    peerDependencies:
+      prettier: ^2 || ^3
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+
   stream-combiner@0.0.4:
     resolution: {integrity: sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==}
 
@@ -6187,6 +6307,9 @@ packages:
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -6311,6 +6434,10 @@ packages:
   type-fest@0.8.1:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
     engines: {node: '>=8'}
+
+  type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
 
   typed-array-buffer@1.0.2:
     resolution: {integrity: sha512-gEymJYKZtKXzzBzM4jqa9w6Q1Jjm7x2d+sh19AdsD4wqnMPDYyvwpsIc2Q/835kHuo3BEQ7CjelGhfTsoBb2MQ==}
@@ -6643,6 +6770,9 @@ packages:
   vue-component-type-helpers@2.0.29:
     resolution: {integrity: sha512-58i+ZhUAUpwQ+9h5Hck0D+jr1qbYl4voRt5KffBx8qzELViQ4XdT/Tuo+mzq8u63teAG8K0lLaOiL5ofqW38rg==}
 
+  vue-component-type-helpers@2.2.10:
+    resolution: {integrity: sha512-iDUO7uQK+Sab2tYuiP9D1oLujCWlhHELHMgV/cB13cuGbG4qwkLHvtfWb6FzvxrIOPDnU0oHsz2MlQjhYDeaHA==}
+
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
     engines: {node: '>=12'}
@@ -6942,6 +7072,8 @@ snapshots:
   '@4tw/cypress-drag-drop@2.3.0(cypress@14.4.0)':
     dependencies:
       cypress: 14.4.0
+
+  '@adobe/css-tools@4.4.3': {}
 
   '@akryum/tinypool@0.3.1': {}
 
@@ -8881,6 +9013,23 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@storybook/addon-actions@9.0.8': {}
+
+  '@storybook/addon-links@9.0.10(storybook@9.0.10(@testing-library/dom@10.4.0))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      storybook: 9.0.10(@testing-library/dom@10.4.0)
+
+  '@storybook/global@5.0.0': {}
+
+  '@storybook/vue3@9.0.10(storybook@9.0.10(@testing-library/dom@10.4.0))(vue@3.5.16(typescript@5.8.3))':
+    dependencies:
+      '@storybook/global': 5.0.0
+      storybook: 9.0.10(@testing-library/dom@10.4.0)
+      type-fest: 2.19.0
+      vue: 3.5.16(typescript@5.8.3)
+      vue-component-type-helpers: 2.2.10
+
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     dependencies:
       ejs: 3.1.10
@@ -8891,6 +9040,31 @@ snapshots:
   '@szmarczak/http-timer@1.1.2':
     dependencies:
       defer-to-connect: 1.1.3
+
+  '@testing-library/dom@10.4.0':
+    dependencies:
+      '@babel/code-frame': 7.26.2
+      '@babel/runtime': 7.25.4
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      chalk: 4.1.2
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.6.3':
+    dependencies:
+      '@adobe/css-tools': 4.4.3
+      aria-query: 5.3.2
+      chalk: 3.0.0
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      lodash: 4.17.21
+      redent: 3.0.0
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
 
   '@tiptap/core@2.13.0(@tiptap/pm@2.13.0)':
     dependencies:
@@ -9109,6 +9283,8 @@ snapshots:
   '@trysound/sax@0.2.0': {}
 
   '@tsconfig/node22@22.0.2': {}
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/codemirror@5.60.15':
     dependencies:
@@ -9402,6 +9578,13 @@ snapshots:
       vite: 6.3.5(@types/node@22.15.24)(jiti@2.4.2)(sass-embedded@1.89.0)(sass@1.80.6)(terser@5.31.6)(yaml@2.5.0)
       vue: 3.5.16(typescript@5.8.3)
 
+  '@vitest/expect@3.0.9':
+    dependencies:
+      '@vitest/spy': 3.0.9
+      '@vitest/utils': 3.0.9
+      chai: 5.2.0
+      tinyrainbow: 2.0.0
+
   '@vitest/expect@3.1.4':
     dependencies:
       '@vitest/spy': 3.1.4
@@ -9416,6 +9599,10 @@ snapshots:
       magic-string: 0.30.17
     optionalDependencies:
       vite: 6.3.5(@types/node@22.15.24)(jiti@2.4.2)(sass-embedded@1.89.0)(sass@1.80.6)(terser@5.31.6)(yaml@2.5.0)
+
+  '@vitest/pretty-format@3.0.9':
+    dependencies:
+      tinyrainbow: 2.0.0
 
   '@vitest/pretty-format@3.1.4':
     dependencies:
@@ -9432,9 +9619,19 @@ snapshots:
       magic-string: 0.30.17
       pathe: 2.0.3
 
+  '@vitest/spy@3.0.9':
+    dependencies:
+      tinyspy: 3.0.2
+
   '@vitest/spy@3.1.4':
     dependencies:
       tinyspy: 3.0.2
+
+  '@vitest/utils@3.0.9':
+    dependencies:
+      '@vitest/pretty-format': 3.0.9
+      loupe: 3.1.3
+      tinyrainbow: 2.0.0
 
   '@vitest/utils@3.1.4':
     dependencies:
@@ -9751,6 +9948,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.1: {}
 
   any-promise@1.3.0: {}
@@ -9769,6 +9968,12 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
 
   array-buffer-byte-length@1.0.1:
     dependencies:
@@ -9797,6 +10002,10 @@ snapshots:
   assertion-error@2.0.1: {}
 
   ast-types@0.13.4:
+    dependencies:
+      tslib: 2.7.0
+
+  ast-types@0.16.1:
     dependencies:
       tslib: 2.7.0
 
@@ -9894,6 +10103,10 @@ snapshots:
   bcrypt-pbkdf@1.0.2:
     dependencies:
       tweetnacl: 0.14.5
+
+  better-opn@3.0.2:
+    dependencies:
+      open: 8.4.2
 
   binary-extensions@2.3.0: {}
 
@@ -10256,6 +10469,8 @@ snapshots:
 
   css-what@6.1.0: {}
 
+  css.escape@1.5.1: {}
+
   cssdb@8.3.0: {}
 
   cssesc@3.0.0: {}
@@ -10449,6 +10664,10 @@ snapshots:
 
   dlv@1.1.3: {}
 
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
+
   dom-serializer@1.4.1:
     dependencies:
       domelementtype: 2.3.0
@@ -10629,6 +10848,13 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.0.5
       is-symbol: 1.0.4
+
+  esbuild-register@3.6.0(esbuild@0.25.5):
+    dependencies:
+      debug: 4.4.1(supports-color@8.1.1)
+      esbuild: 0.25.5
+    transitivePeerDependencies:
+      - supports-color
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -11772,6 +11998,8 @@ snapshots:
 
   lru-cache@7.18.3: {}
 
+  lz-string@1.5.0: {}
+
   magic-string@0.25.9:
     dependencies:
       sourcemap-codec: 1.4.8
@@ -12486,6 +12714,12 @@ snapshots:
 
   pretty-bytes@6.1.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-ms@9.2.0:
     dependencies:
       parse-ms: 4.0.0
@@ -12683,6 +12917,8 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
+  react-is@17.0.2: {}
+
   read-cache@1.0.0:
     dependencies:
       pify: 2.3.0
@@ -12711,6 +12947,14 @@ snapshots:
       picomatch: 2.3.1
 
   readdirp@4.1.2: {}
+
+  recast@0.23.11:
+    dependencies:
+      ast-types: 0.16.1
+      esprima: 4.0.1
+      source-map: 0.6.1
+      tiny-invariant: 1.3.3
+      tslib: 2.7.0
 
   redent@3.0.0:
     dependencies:
@@ -13190,6 +13434,25 @@ snapshots:
 
   std-env@3.9.0: {}
 
+  storybook@9.0.10(@testing-library/dom@10.4.0):
+    dependencies:
+      '@storybook/global': 5.0.0
+      '@testing-library/jest-dom': 6.6.3
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
+      '@vitest/expect': 3.0.9
+      '@vitest/spy': 3.0.9
+      better-opn: 3.0.2
+      esbuild: 0.25.5
+      esbuild-register: 3.6.0(esbuild@0.25.5)
+      recast: 0.23.11
+      semver: 7.7.1
+      ws: 8.18.0
+    transitivePeerDependencies:
+      - '@testing-library/dom'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   stream-combiner@0.0.4:
     dependencies:
       duplexer: 0.1.2
@@ -13409,6 +13672,8 @@ snapshots:
 
   through@2.3.8: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -13501,6 +13766,8 @@ snapshots:
   type-fest@0.6.0: {}
 
   type-fest@0.8.1: {}
+
+  type-fest@2.19.0: {}
 
   typed-array-buffer@1.0.2:
     dependencies:
@@ -13885,6 +14152,8 @@ snapshots:
       vue: 3.5.16(typescript@5.8.3)
 
   vue-component-type-helpers@2.0.29: {}
+
+  vue-component-type-helpers@2.2.10: {}
 
   vue-demi@0.14.10(vue@3.5.16(typescript@5.8.3)):
     dependencies:

--- a/frontend/src/components/base/BaseButton.stories.ts
+++ b/frontend/src/components/base/BaseButton.stories.ts
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import BaseButton from './BaseButton.vue'
+import { createRouter, createMemoryHistory } from 'vue-router'
+
+const meta: Meta<typeof BaseButton> = {
+    title: 'Base/Button',
+    component: BaseButton,
+    decorators: [() => ({
+        components: { BaseButton },
+        setup() {
+            const router = createRouter({
+                history: createMemoryHistory(),
+                routes: [{ path: '/', name: 'home', component: { render: () => null } }],
+            })
+            return { router }
+        },
+        template: '<story />',
+    })],
+}
+export default meta
+
+type Story = StoryObj<typeof BaseButton>
+
+export const Default: Story = {
+    render: () => ({
+        components: { BaseButton },
+        template: '<BaseButton>Hello!</BaseButton>',
+    }),
+}
+
+export const Disabled: Story = {
+    render: () => ({
+        components: { BaseButton },
+        template: '<BaseButton disabled>Hello!</BaseButton>',
+    }),
+}
+

--- a/frontend/src/components/date/DatemathHelp.stories.ts
+++ b/frontend/src/components/date/DatemathHelp.stories.ts
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import DatemathHelp from './DatemathHelp.vue'
+
+const meta: Meta<typeof DatemathHelp> = {
+    title: 'Date/DatemathHelp',
+    component: DatemathHelp,
+}
+export default meta
+
+type Story = StoryObj<typeof DatemathHelp>
+
+export const Default: Story = {
+    render: () => ({
+        components: { DatemathHelp },
+        template: '<DatemathHelp />',
+    }),
+}

--- a/frontend/src/components/input/Button.stories.ts
+++ b/frontend/src/components/input/Button.stories.ts
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import XButton from './Button.vue'
+
+const meta: Meta<typeof XButton> = {
+    title: 'Input/Button',
+    component: XButton,
+}
+export default meta
+
+type Story = StoryObj<typeof XButton>
+
+export const Primary: Story = {
+    render: () => ({
+        components: { XButton },
+        template: '<XButton variant="primary">Order pizza!</XButton>',
+    }),
+}
+
+export const Secondary: Story = {
+    render: () => ({
+        components: { XButton },
+        template: '<XButton variant="secondary">Order spaghetti!</XButton>',
+    }),
+}
+
+export const Tertiary: Story = {
+    render: () => ({
+        components: { XButton },
+        template: '<XButton variant="tertiary">Order tortellini!</XButton>',
+    }),
+}

--- a/frontend/src/components/input/ColorPicker.stories.ts
+++ b/frontend/src/components/input/ColorPicker.stories.ts
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import { ref } from 'vue'
+import ColorPicker from './ColorPicker.vue'
+
+const meta: Meta<typeof ColorPicker> = {
+    title: 'Input/ColorPicker',
+    component: ColorPicker,
+}
+export default meta
+
+type Story = StoryObj<typeof ColorPicker>
+
+export const Default: Story = {
+    render: () => ({
+        components: { ColorPicker },
+        setup() {
+            const color = ref('#f2f2f2')
+            return { color }
+        },
+        template: '<ColorPicker v-model="color" />',
+    }),
+}

--- a/frontend/src/components/input/FancyCheckbox.stories.ts
+++ b/frontend/src/components/input/FancyCheckbox.stories.ts
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import { ref } from 'vue'
+import FancyCheckbox from './FancyCheckbox.vue'
+
+const meta: Meta<typeof FancyCheckbox> = {
+    title: 'Input/FancyCheckbox',
+    component: FancyCheckbox,
+}
+export default meta
+
+type Story = StoryObj<typeof FancyCheckbox>
+
+export const Default: Story = {
+    render: () => ({
+        components: { FancyCheckbox },
+        setup() {
+            const isChecked = ref(false)
+            return { isChecked }
+        },
+        template: '<FancyCheckbox v-model="isChecked">This is probably not important</FancyCheckbox>\n<input v-model="isChecked" type="checkbox"> {{ isChecked }}',
+    }),
+}
+
+export const EnabledInitially: Story = {
+    render: () => ({
+        components: { FancyCheckbox },
+        setup() {
+            const isCheckedInitiallyEnabled = ref(true)
+            return { isCheckedInitiallyEnabled }
+        },
+        template: '<FancyCheckbox v-model="isCheckedInitiallyEnabled">We want you to use this option</FancyCheckbox>\n<input v-model="isCheckedInitiallyEnabled" type="checkbox"> {{ isCheckedInitiallyEnabled }}',
+    }),
+}
+
+export const Disabled: Story = {
+    render: () => ({
+        components: { FancyCheckbox },
+        setup() {
+            const isCheckedDisabled = ref(false)
+            return { isCheckedDisabled }
+        },
+        template: '<FancyCheckbox disabled :model-value="isCheckedDisabled" />' ,
+    }),
+}
+
+export const UndefinedInitial: Story = {
+    render: () => ({
+        components: { FancyCheckbox },
+        setup() {
+            const withoutInitialState = ref(undefined)
+            return { withoutInitialState }
+        },
+        template: '<FancyCheckbox v-model="withoutInitialState">Not sure what the value should be</FancyCheckbox>\n<input v-model="withoutInitialState" type="checkbox" disabled> {{ withoutInitialState }}',
+    }),
+}

--- a/frontend/src/components/misc/Card.stories.ts
+++ b/frontend/src/components/misc/Card.stories.ts
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import Card from './Card.vue'
+
+const meta: Meta<typeof Card> = {
+    title: 'Misc/Card',
+    component: Card,
+}
+export default meta
+
+type Story = StoryObj<typeof Card>
+
+export const Default: Story = {
+    render: () => ({
+        components: { Card },
+        template: '<Card>Card content</Card>',
+    }),
+}

--- a/frontend/src/components/misc/ProgressBar.stories.ts
+++ b/frontend/src/components/misc/ProgressBar.stories.ts
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import { ref } from 'vue'
+import ProgressBar from './ProgressBar.vue'
+
+const meta: Meta<typeof ProgressBar> = {
+    title: 'Misc/ProgressBar',
+    component: ProgressBar,
+}
+export default meta
+
+type Story = StoryObj<typeof ProgressBar>
+
+export const Default: Story = {
+    render: () => ({
+        components: { ProgressBar },
+        setup() {
+            const value = ref(50)
+            return { value }
+        },
+        template: '<ProgressBar :value="value" />',
+    }),
+}

--- a/frontend/src/components/project/partials/FilterInput.stories.ts
+++ b/frontend/src/components/project/partials/FilterInput.stories.ts
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import FilterInput from '@/components/project/partials/FilterInput.vue'
+
+const meta: Meta<typeof FilterInput> = {
+    title: 'Project/FilterInput',
+    component: FilterInput,
+}
+export default meta
+
+type Story = StoryObj<typeof FilterInput>
+
+export const WithDateValues: Story = {
+    render: () => ({
+        components: { FilterInput },
+        setup() {
+            const value = 'dueDate < now && done = false && dueDate > now/w+1w'
+            return { value }
+        },
+        template: '<FilterInput v-model="value" />',
+    }),
+}

--- a/frontend/src/components/tasks/partials/Reminders.stories.ts
+++ b/frontend/src/components/tasks/partials/Reminders.stories.ts
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import { ref } from 'vue'
+import Reminders from './Reminders.vue'
+import ReminderDetail from '@/components/tasks/partials/ReminderDetail.vue'
+
+const meta: Meta<typeof Reminders> = {
+    title: 'Tasks/Reminders',
+    component: Reminders,
+}
+export default meta
+
+type Story = StoryObj<typeof Reminders>
+
+export const Default: Story = {
+    render: () => ({
+        components: { Reminders },
+        template: '<Reminders />',
+    }),
+}
+
+export const WithDetails: Story = {
+    render: () => ({
+        components: { ReminderDetail },
+        setup() {
+            const reminderNow = ref({ reminder: new Date(), relativePeriod: 0, relativeTo: null })
+            const relativeReminder = ref({ reminder: null, relativePeriod: 1, relativeTo: 'due_date' })
+            const newReminder = ref(null)
+            return { reminderNow, relativeReminder, newReminder }
+        },
+        template: '<ReminderDetail v-model="reminderNow" />\n<ReminderDetail v-model="relativeReminder" />\n<ReminderDetail v-model="newReminder" />',
+    }),
+}

--- a/frontend/src/storybook.setup.ts
+++ b/frontend/src/storybook.setup.ts
@@ -1,0 +1,25 @@
+import {setup} from '@storybook/vue3'
+import {createPinia} from 'pinia'
+import {i18n} from './i18n'
+
+import cypress from '@/directives/cypress'
+import FontAwesomeIcon from '@/components/misc/Icon'
+import XButton from '@/components/input/button.vue'
+import Modal from '@/components/misc/Modal.vue'
+import Card from '@/components/misc/Card.vue'
+
+import './styles/global.scss'
+
+setup(app => {
+    const pinia = createPinia()
+    app.use(pinia)
+    app.use(i18n)
+
+    app.directive('cy', cypress)
+
+    app.component('Icon', FontAwesomeIcon)
+    app.component('XButton', XButton)
+    app.component('Modal', Modal)
+    app.component('Card', Card)
+})
+


### PR DESCRIPTION
## Summary
- install Storybook dependencies
- generate basic configuration
- add a simple BaseButton story
- wire global setup and preview config
- document how to run Storybook

## Testing
- `pnpm --dir frontend lint`
- `pnpm --dir frontend typecheck` *(fails: existing errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_684fbc5b74808320bdd2297a621e75db