### PR TITLE
Fix file descriptor leak in task attachment upload

### DIFF
--- a/pkg/routes/api/v1/task_attachment.go
+++ b/pkg/routes/api/v1/task_attachment.go
@@ -96,9 +96,9 @@ func UploadTaskAttachment(c echo.Context) error {
 			r.Errors = append(r.Errors, handler.HandleHTTPError(err))
 			continue
 		}
-		defer f.Close()
 
 		err = ta.NewAttachment(s, f, file.Filename, uint64(file.Size), auth)
+		_ = f.Close()
 		if err != nil {
 			r.Errors = append(r.Errors, handler.HandleHTTPError(err))
 			continue


### PR DESCRIPTION
## Summary
- close each file immediately during task attachment upload

## Testing
- `mage lint`
- `mage test:unit`


------
https://chatgpt.com/codex/tasks/task_e_684fbf8704348320a2589c49b1601ca2