### PR TITLE
Fix unsplash pingback HTTP response cleanup

### DIFF
--- a/pkg/modules/background/unsplash/unsplash.go
+++ b/pkg/modules/background/unsplash/unsplash.go
@@ -343,9 +343,12 @@ func pingbackByPhotoID(photoID string) {
 	if err != nil {
 		log.Errorf("Unsplash Pingback Failed: %s", err.Error())
 	}
-	_, err = http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Errorf("Unsplash Pingback Failed: %s", err.Error())
+		return
 	}
+	defer resp.Body.Close()
+
 	log.Debugf("Pinged unsplash for photo %s", photoID)
 }


### PR DESCRIPTION
## Summary
- ensure pingback HTTP response is closed

## Testing
- `mage test:unit` *(fails: signal interrupt)*
- `mage lint` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68500a6f2a888320801ab77eae834c6f