### PR TITLE
Fix avatar file descriptor leak

### DIFF
--- a/pkg/modules/avatar/upload/upload.go
+++ b/pkg/modules/avatar/upload/upload.go
@@ -81,6 +81,7 @@ func (p *Provider) GetAvatar(u *user.User, size int64) (avatar []byte, mimeType 
 	}
 
 	img, _, err := image.Decode(f.File)
+	_ = f.File.Close()
 	if err != nil {
 		return nil, "", err
 	}


### PR DESCRIPTION
## Summary
- ensure avatar file handles get closed after decoding

## Testing
- `mage lint`
- `mage test:unit`
- `mage test:integration`


------
https://chatgpt.com/codex/tasks/task_e_68500a677f1483208be9b2ee60b6dbb6