### PR TITLE
Fix export file closing order

### DIFF
--- a/pkg/models/export.go
+++ b/pkg/models/export.go
@@ -94,6 +94,12 @@ func ExportUserData(s *xorm.Session, u *user.User) (err error) {
 	if err != nil {
 		return err
 	}
+	exportedName := exported.Name()
+	defer func() {
+		if exported != nil {
+			_ = exported.Close()
+		}
+	}()
 
 	stat, err := exported.Stat()
 	if err != nil {
@@ -116,7 +122,11 @@ func ExportUserData(s *xorm.Session, u *user.User) (err error) {
 	}
 
 	// Remove the old file
-	err = os.Remove(exported.Name())
+	if err := exported.Close(); err != nil {
+		return err
+	}
+	exported = nil
+	err = os.Remove(exportedName)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- fix closing the export file before removing it

## Testing
- `mage test:unit`
- `mage test:integration`


------
https://chatgpt.com/codex/tasks/task_e_68500a63c9a08320ba7a961aae753f79