### PR TITLE
Fix dotenv leak in restore

### DIFF
--- a/pkg/modules/dump/restore.go
+++ b/pkg/modules/dump/restore.go
@@ -333,8 +333,10 @@ func restoreConfig(configFile, dotEnvFile *zip.File) error {
 		buf := bytes.Buffer{}
 		_, err = buf.ReadFrom(dotenv)
 		if err != nil {
+			_ = dotenv.Close()
 			return err
 		}
+		_ = dotenv.Close()
 
 		log.Warningf("Please make sure the following settings are properly configured in your instance:\n%s", buf.String())
 		log.Warning("Make sure your current config matches the following env variables, confirm by pressing enter when done.")


### PR DESCRIPTION
## Summary
- close dotenv zip file handle after reading its contents

## Testing
- `mage lint`
- `VIKUNJA_SERVICE_ROOTPATH=$(pwd) mage test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68500a61ec9c8320b1948eadf6afa699