### PR TITLE
fix(dump): close version file after open

### DIFF
--- a/pkg/modules/dump/restore.go
+++ b/pkg/modules/dump/restore.go
@@ -355,6 +355,7 @@ func checkVikunjaVersion(versionFile *zip.File) error {
 	if err != nil {
 		return fmt.Errorf("could not open version file: %w", err)
 	}
+	defer vf.Close()
 
 	var bufVersion bytes.Buffer
 	if _, err := bufVersion.ReadFrom(vf); err != nil {


### PR DESCRIPTION
## Summary
- close the version file immediately after opening in dump restore

## Testing
- `mage lint`
- `VIKUNJA_SERVICE_ROOTPATH=$(pwd) mage test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68500a5c1a8883208c98dd4c96a1f945