### PR TITLE
Fix descriptor handling in vikunja-file migrator

### DIFF
--- a/pkg/modules/migration/vikunja-file/vikunja.go
+++ b/pkg/modules/migration/vikunja-file/vikunja.go
@@ -246,8 +246,10 @@ func addDetailsToProject(l *models.ProjectWithTasksAndBuckets, storedFiles map[i
 		}
 		var buf bytes.Buffer
 		if _, err := buf.ReadFrom(bf); err != nil {
+			bf.Close()
 			return fmt.Errorf("could not read project background file %d: %w", l.BackgroundFileID, err)
 		}
+		bf.Close()
 
 		l.BackgroundInformation = &buf
 	}
@@ -272,9 +274,11 @@ func addDetailsToProject(l *models.ProjectWithTasksAndBuckets, storedFiles map[i
 			}
 			var buf bytes.Buffer
 			if _, err := buf.ReadFrom(af); err != nil {
+				af.Close()
 				log.Warningf(logPrefix+"Could not read attachment %d: %v, skipping", attachment.ID, err)
 				continue
 			}
+			af.Close()
 
 			attachment.ID = 0
 			attachment.File.ID = 0


### PR DESCRIPTION
## Summary
- close attachment file readers after processing to avoid descriptor leaks
- close project background files once read

## Testing
- `mage lint`
- `mage test:unit`
- `mage test:integration`


------
https://chatgpt.com/codex/tasks/task_e_68500a5812908320b74451e1229685a1