### PR TITLE
Fix background file closure in Vikunja export import

### DIFF
--- a/pkg/modules/migration/vikunja-file/vikunja.go
+++ b/pkg/modules/migration/vikunja-file/vikunja.go
@@ -245,8 +245,13 @@ func addDetailsToProject(l *models.ProjectWithTasksAndBuckets, storedFiles map[i
 			return fmt.Errorf("could not open project background file %d for reading: %w", l.BackgroundFileID, err)
 		}
 		var buf bytes.Buffer
-		if _, err := buf.ReadFrom(bf); err != nil {
-			return fmt.Errorf("could not read project background file %d: %w", l.BackgroundFileID, err)
+		_, readErr := buf.ReadFrom(bf)
+		closeErr := bf.Close()
+		if readErr != nil {
+			return fmt.Errorf("could not read project background file %d: %w", l.BackgroundFileID, readErr)
+		}
+		if closeErr != nil {
+			return fmt.Errorf("could not close project background file %d: %w", l.BackgroundFileID, closeErr)
 		}
 
 		l.BackgroundInformation = &buf


### PR DESCRIPTION
## Summary
- close the background file after copying its contents during Vikunja File migration

## Testing
- `golangci-lint run ./pkg/...`
- `VIKUNJA_SERVICE_ROOTPATH=$(pwd) mage test:unit`
- `VIKUNJA_SERVICE_ROOTPATH=$(pwd) mage test:integration`


------
https://chatgpt.com/codex/tasks/task_e_68500a5422e083208226b31b196c8234