### PR TITLE
Fix file handle leak in file migration

### DIFF
--- a/pkg/modules/migration/vikunja-file/vikunja.go
+++ b/pkg/modules/migration/vikunja-file/vikunja.go
@@ -120,6 +120,7 @@ func (v *FileMigrator) Migrate(user *user.User, file io.ReaderAt, size int64) er
 	if err != nil {
 		return fmt.Errorf("could not open version file: %w", err)
 	}
+	defer vf.Close()
 
 	var bufVersion bytes.Buffer
 	if _, err := bufVersion.ReadFrom(vf); err != nil {


### PR DESCRIPTION
## Summary
- close VERSION file after reading during vikunja-file import

## Testing
- `mage lint`
- `VIKUNJA_SERVICE_ROOTPATH=$(pwd) mage test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68500a511c8c83208c02e35355c59734