### PR TITLE
Add stories for key components

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -2,7 +2,8 @@ import type { StorybookConfig } from '@storybook/vue3';
 
 const config: StorybookConfig = {
   stories: [
-    '../src/**/*.stories.@(ts|js|vue)'
+    '../src/**/*.stories.@(ts|js|vue)',
+    '../src/**/*.story.@(ts|js|vue)'
   ],
   addons: [
     '@storybook/addon-actions',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -119,6 +119,7 @@
     "@storybook/addon-actions": "^9.0.8",
     "@storybook/addon-links": "^9.0.10",
     "@storybook/vue3": "^9.0.10",
+    "storybook": "^9.0.10",
     "@tsconfig/node22": "22.0.2",
     "@types/codemirror": "5.60.15",
     "@types/is-touch-device": "1.0.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -305,6 +305,9 @@ importers:
       start-server-and-test:
         specifier: 2.0.12
         version: 2.0.12
+      storybook:
+        specifier: ^9.0.10
+        version: 9.0.10(@testing-library/dom@10.4.0)
       typescript:
         specifier: 5.8.3
         version: 5.8.3

--- a/frontend/src/components/base/BaseCheckbox.stories.ts
+++ b/frontend/src/components/base/BaseCheckbox.stories.ts
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import BaseCheckbox from './BaseCheckbox.vue'
+
+const meta: Meta<typeof BaseCheckbox> = {
+    title: 'Base/Checkbox',
+    component: BaseCheckbox,
+}
+export default meta
+
+type Story = StoryObj<typeof BaseCheckbox>
+
+export const Default: Story = {
+    render: () => ({
+        components: { BaseCheckbox },
+        data() {
+            return { checked: false }
+        },
+        template: '<BaseCheckbox v-model="checked">Check me</BaseCheckbox>',
+    }),
+}

--- a/frontend/src/components/base/BasePagination.stories.ts
+++ b/frontend/src/components/base/BasePagination.stories.ts
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import BasePagination from './BasePagination.vue'
+
+const meta: Meta<typeof BasePagination> = {
+    title: 'Base/Pagination',
+    component: BasePagination,
+}
+export default meta
+
+type Story = StoryObj<typeof BasePagination>
+
+export const Default: Story = {
+    render: () => ({
+        components: { BasePagination },
+        template: `
+            <BasePagination :total-pages="5" :current-page="2">
+                <template #previous="{ disabled }">
+                    <button class="pagination-previous" :disabled="disabled">Prev</button>
+                </template>
+                <template #next="{ disabled }">
+                    <button class="pagination-next" :disabled="disabled">Next</button>
+                </template>
+                <template #page-link="{ page, isCurrent }">
+                    <button class="pagination-link" :class="{ 'is-current': isCurrent }">{{ page.number }}</button>
+                </template>
+            </BasePagination>
+        `,
+    }),
+}

--- a/frontend/src/components/base/Expandable.stories.ts
+++ b/frontend/src/components/base/Expandable.stories.ts
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import Expandable from './Expandable.vue'
+import BaseButton from './BaseButton.vue'
+
+const meta: Meta<typeof Expandable> = {
+    title: 'Base/Expandable',
+    component: Expandable,
+}
+export default meta
+
+type Story = StoryObj<typeof Expandable>
+
+export const Default: Story = {
+    render: () => ({
+        components: { Expandable, BaseButton },
+        data() {
+            return { open: false }
+        },
+        template: `
+            <div>
+                <BaseButton @click="open = !open">Toggle</BaseButton>
+                <Expandable :open="open" :initial-height="60">
+                    <p>This is some long text that will be expanded when the button is clicked. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </Expandable>
+            </div>
+        `,
+    }),
+}

--- a/frontend/src/components/date/DatepickerWithRange.stories.ts
+++ b/frontend/src/components/date/DatepickerWithRange.stories.ts
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import { reactive } from 'vue'
+import DatepickerWithRange from './DatepickerWithRange.vue'
+import BaseButton from '@/components/base/BaseButton.vue'
+
+const meta: Meta<typeof DatepickerWithRange> = {
+    title: 'Date/DatepickerWithRange',
+    component: DatepickerWithRange,
+}
+export default meta
+
+type Story = StoryObj<typeof DatepickerWithRange>
+
+export const Default: Story = {
+    render: () => ({
+        components: { DatepickerWithRange, BaseButton },
+        setup() {
+            const range = reactive({ dateFrom: '', dateTo: '' })
+            return { range }
+        },
+        template: `
+            <DatepickerWithRange v-model="range">
+                <template #trigger="{ toggle }">
+                    <BaseButton @click="toggle">Select Range</BaseButton>
+                </template>
+            </DatepickerWithRange>
+        `,
+    }),
+}

--- a/frontend/src/components/date/DatepickerWithValues.stories.ts
+++ b/frontend/src/components/date/DatepickerWithValues.stories.ts
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import { ref } from 'vue'
+import DatepickerWithValues from './DatepickerWithValues.vue'
+import BaseButton from '@/components/base/BaseButton.vue'
+
+const meta: Meta<typeof DatepickerWithValues> = {
+    title: 'Date/DatepickerWithValues',
+    component: DatepickerWithValues,
+}
+export default meta
+
+type Story = StoryObj<typeof DatepickerWithValues>
+
+export const Default: Story = {
+    render: () => ({
+        components: { DatepickerWithValues, BaseButton },
+        setup() {
+            const date = ref<string | Date | null>(null)
+            const open = ref(true)
+            return { date, open }
+        },
+        template: `
+            <DatepickerWithValues v-model="date" :open="open" @update:open="open = $event">
+                <template #trigger="{ toggle }">
+                    <BaseButton @click="toggle">Pick Date</BaseButton>
+                </template>
+            </DatepickerWithValues>
+        `,
+    }),
+}

--- a/frontend/src/components/home/AddToHomeScreen.stories.ts
+++ b/frontend/src/components/home/AddToHomeScreen.stories.ts
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import AddToHomeScreen from './AddToHomeScreen.vue'
+import { useBaseStore } from '@/stores/base'
+
+const meta: Meta<typeof AddToHomeScreen> = {
+    title: 'Home/AddToHomeScreen',
+    component: AddToHomeScreen,
+}
+export default meta
+
+type Story = StoryObj<typeof AddToHomeScreen>
+
+export const Default: Story = {
+    render: () => ({
+        components: { AddToHomeScreen },
+        setup() {
+            const baseStore = useBaseStore()
+            baseStore.setUpdateAvailable(false)
+            localStorage.setItem('hideAddToHomeScreenMessage', 'false')
+            return {}
+        },
+        template: '<AddToHomeScreen />',
+    }),
+}

--- a/frontend/src/components/home/Logo.stories.ts
+++ b/frontend/src/components/home/Logo.stories.ts
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import Logo from './Logo.vue'
+
+const meta: Meta<typeof Logo> = {
+    title: 'Home/Logo',
+    component: Logo,
+}
+export default meta
+
+type Story = StoryObj<typeof Logo>
+
+export const Default: Story = {
+    render: () => ({
+        components: { Logo },
+        template: '<Logo />',
+    }),
+}

--- a/frontend/src/components/home/MenuButton.stories.ts
+++ b/frontend/src/components/home/MenuButton.stories.ts
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import MenuButton from './MenuButton.vue'
+import { useBaseStore } from '@/stores/base'
+
+const meta: Meta<typeof MenuButton> = {
+    title: 'Home/MenuButton',
+    component: MenuButton,
+}
+export default meta
+
+type Story = StoryObj<typeof MenuButton>
+
+export const Default: Story = {
+    render: () => ({
+        components: { MenuButton },
+        setup() {
+            const baseStore = useBaseStore()
+            baseStore.menuActive = false
+            return {}
+        },
+        template: '<MenuButton />',
+    }),
+}

--- a/frontend/src/components/home/UpdateNotification.stories.ts
+++ b/frontend/src/components/home/UpdateNotification.stories.ts
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import UpdateNotification from './UpdateNotification.vue'
+import { useBaseStore } from '@/stores/base'
+
+const meta: Meta<typeof UpdateNotification> = {
+    title: 'Home/UpdateNotification',
+    component: UpdateNotification,
+}
+export default meta
+
+type Story = StoryObj<typeof UpdateNotification>
+
+export const Default: Story = {
+    render: () => ({
+        components: { UpdateNotification },
+        setup() {
+            const baseStore = useBaseStore()
+            baseStore.setUpdateAvailable(true)
+            return {}
+        },
+        template: '<UpdateNotification />',
+    }),
+}

--- a/frontend/src/components/input/AutocompleteDropdown.stories.ts
+++ b/frontend/src/components/input/AutocompleteDropdown.stories.ts
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import { ref } from 'vue'
+import AutocompleteDropdown from './AutocompleteDropdown.vue'
+
+const meta: Meta<typeof AutocompleteDropdown> = {
+    title: 'Input/AutocompleteDropdown',
+    component: AutocompleteDropdown,
+}
+export default meta
+
+type Story = StoryObj<typeof AutocompleteDropdown>
+
+export const Default: Story = {
+    render: () => ({
+        components: { AutocompleteDropdown },
+        setup() {
+            const value = ref('')
+            const options = ['Apple', 'Banana', 'Cherry']
+            return { value, options }
+        },
+        template: `
+            <AutocompleteDropdown v-model="value" :options="options">
+                <template #input="{ onUpdateField, onFocusField, onKeydown }">
+                    <input class="input" :value="value" @input="onUpdateField" @focus="onFocusField" @keydown="onKeydown" />
+                </template>
+            </AutocompleteDropdown>
+        `,
+    }),
+}

--- a/frontend/src/components/input/Datepicker.stories.ts
+++ b/frontend/src/components/input/Datepicker.stories.ts
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import { ref } from 'vue'
+import Datepicker from './Datepicker.vue'
+
+const meta: Meta<typeof Datepicker> = {
+    title: 'Input/Datepicker',
+    component: Datepicker,
+}
+export default meta
+
+type Story = StoryObj<typeof Datepicker>
+
+export const Default: Story = {
+    render: () => ({
+        components: { Datepicker },
+        setup() {
+            const date = ref<Date | null>(null)
+            return { date }
+        },
+        template: '<Datepicker v-model="date" />',
+    }),
+}

--- a/frontend/src/components/input/SimpleButton.stories.ts
+++ b/frontend/src/components/input/SimpleButton.stories.ts
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import SimpleButton from './SimpleButton.vue'
+
+const meta: Meta<typeof SimpleButton> = {
+    title: 'Input/SimpleButton',
+    component: SimpleButton,
+}
+export default meta
+
+type Story = StoryObj<typeof SimpleButton>
+
+export const Default: Story = {
+    render: () => ({
+        components: { SimpleButton },
+        template: '<SimpleButton>Click me</SimpleButton>',
+    }),
+}

--- a/frontend/src/components/misc/Dropdown.stories.ts
+++ b/frontend/src/components/misc/Dropdown.stories.ts
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import Dropdown from './Dropdown.vue'
+import DropdownItem from './DropdownItem.vue'
+import BaseButton from '@/components/base/BaseButton.vue'
+
+const meta: Meta<typeof Dropdown> = {
+    title: 'Misc/Dropdown',
+    component: Dropdown,
+}
+export default meta
+
+type Story = StoryObj<typeof Dropdown>
+
+export const Default: Story = {
+    render: () => ({
+        components: { Dropdown, DropdownItem, BaseButton },
+        template: `
+            <Dropdown>
+                <template #trigger="{ toggleOpen }">
+                    <BaseButton @click="toggleOpen">Open</BaseButton>
+                </template>
+                <DropdownItem>One</DropdownItem>
+                <DropdownItem>Two</DropdownItem>
+            </Dropdown>
+        `,
+    }),
+}

--- a/frontend/src/components/misc/DropdownItem.stories.ts
+++ b/frontend/src/components/misc/DropdownItem.stories.ts
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import DropdownItem from './DropdownItem.vue'
+
+const meta: Meta<typeof DropdownItem> = {
+    title: 'Misc/DropdownItem',
+    component: DropdownItem,
+}
+export default meta
+
+type Story = StoryObj<typeof DropdownItem>
+
+export const Default: Story = {
+    render: () => ({
+        components: { DropdownItem },
+        template: '<DropdownItem>Item</DropdownItem>',
+    }),
+}

--- a/frontend/src/components/misc/Modal.stories.ts
+++ b/frontend/src/components/misc/Modal.stories.ts
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import { ref } from 'vue'
+import Modal from './Modal.vue'
+import BaseButton from '@/components/base/BaseButton.vue'
+
+const meta: Meta<typeof Modal> = {
+    title: 'Misc/Modal',
+    component: Modal,
+}
+export default meta
+
+type Story = StoryObj<typeof Modal>
+
+export const Default: Story = {
+    render: () => ({
+        components: { Modal, BaseButton },
+        setup() {
+            const open = ref(true)
+            return { open }
+        },
+        template: `
+            <Modal :enabled="open" @close="open = false">
+                <template #default>
+                    <div class="p-4">This is a modal</div>
+                </template>
+            </Modal>
+            <BaseButton @click="open = true">Open Modal</BaseButton>
+        `,
+    }),
+}

--- a/frontend/src/components/misc/Popup.stories.ts
+++ b/frontend/src/components/misc/Popup.stories.ts
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import { ref } from 'vue'
+import Popup from './Popup.vue'
+import BaseButton from '@/components/base/BaseButton.vue'
+
+const meta: Meta<typeof Popup> = {
+    title: 'Misc/Popup',
+    component: Popup,
+}
+export default meta
+
+type Story = StoryObj<typeof Popup>
+
+export const Default: Story = {
+    render: () => ({
+        components: { Popup, BaseButton },
+        setup() {
+            const open = ref(false)
+            return { open }
+        },
+        template: `
+            <Popup :open="open" @update:open="open = $event">
+                <template #trigger="{ toggle }">
+                    <BaseButton @click="toggle">Toggle</BaseButton>
+                </template>
+                <template #content>
+                    <div class="p-2">Content</div>
+                </template>
+            </Popup>
+        `,
+    }),
+}

--- a/frontend/src/components/project/partials/ProjectCard.stories.ts
+++ b/frontend/src/components/project/partials/ProjectCard.stories.ts
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import ProjectCard from './ProjectCard.vue'
+import ProjectModel from '@/models/project'
+
+const meta: Meta<typeof ProjectCard> = {
+    title: 'Project/ProjectCard',
+    component: ProjectCard,
+}
+export default meta
+
+type Story = StoryObj<typeof ProjectCard>
+
+export const Default: Story = {
+    render: () => ({
+        components: { ProjectCard },
+        setup() {
+            const project = new ProjectModel({ id: 1, title: 'Storybook Project' })
+            return { project }
+        },
+        template: '<ProjectCard :project="project" />',
+    }),
+}

--- a/frontend/src/components/project/partials/ProjectCardGrid.stories.ts
+++ b/frontend/src/components/project/partials/ProjectCardGrid.stories.ts
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import ProjectCardGrid from './ProjectCardGrid.vue'
+import ProjectModel from '@/models/project'
+
+const meta: Meta<typeof ProjectCardGrid> = {
+    title: 'Project/ProjectCardGrid',
+    component: ProjectCardGrid,
+}
+export default meta
+
+type Story = StoryObj<typeof ProjectCardGrid>
+
+export const Default: Story = {
+    render: () => ({
+        components: { ProjectCardGrid },
+        setup() {
+            const projects = [
+                new ProjectModel({ id: 1, title: 'One' }),
+                new ProjectModel({ id: 2, title: 'Two' }),
+            ]
+            return { projects }
+        },
+        template: '<ProjectCardGrid :projects="projects" />',
+    }),
+}

--- a/frontend/src/components/quick-actions/QuickActions.stories.ts
+++ b/frontend/src/components/quick-actions/QuickActions.stories.ts
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import QuickActions from './QuickActions.vue'
+import { useBaseStore } from '@/stores/base'
+
+const meta: Meta<typeof QuickActions> = {
+    title: 'QuickActions/QuickActions',
+    component: QuickActions,
+}
+export default meta
+
+type Story = StoryObj<typeof QuickActions>
+
+export const Default: Story = {
+    render: () => ({
+        components: { QuickActions },
+        setup() {
+            const baseStore = useBaseStore()
+            baseStore.setQuickActionsActive(true)
+            return {}
+        },
+        template: '<QuickActions />',
+    }),
+}

--- a/frontend/src/components/sharing/LinkSharing.stories.ts
+++ b/frontend/src/components/sharing/LinkSharing.stories.ts
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import LinkSharing from './LinkSharing.vue'
+import LinkShareService from '@/services/linkShare'
+import LinkShareModel from '@/models/linkShare'
+
+const meta: Meta<typeof LinkSharing> = {
+    title: 'Sharing/LinkSharing',
+    component: LinkSharing,
+}
+export default meta
+
+type Story = StoryObj<typeof LinkSharing>
+
+export const Default: Story = {
+    render: () => ({
+        components: { LinkSharing },
+        setup() {
+            // stub service
+            LinkShareService.prototype.getAll = async () => [
+                new LinkShareModel({ id: 1, name: 'Public Link' }),
+            ]
+            LinkShareService.prototype.create = async () => new LinkShareModel({ id: 2 })
+            LinkShareService.prototype.delete = async () => {}
+            return {}
+        },
+        template: '<LinkSharing project-id="1" />',
+    }),
+}

--- a/frontend/src/components/sharing/UserTeam.stories.ts
+++ b/frontend/src/components/sharing/UserTeam.stories.ts
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import UserTeam from './UserTeam.vue'
+import UserProjectService from '@/services/userProject'
+import UserProjectModel from '@/models/userProject'
+import UserModel from '@/models/user'
+
+const meta: Meta<typeof UserTeam> = {
+    title: 'Sharing/UserTeam',
+    component: UserTeam,
+}
+export default meta
+
+type Story = StoryObj<typeof UserTeam>
+
+export const Default: Story = {
+    render: () => ({
+        components: { UserTeam },
+        setup() {
+            UserProjectService.prototype.getAll = async () => [
+                new UserModel({ id: 1, username: 'tester' }),
+            ]
+            UserProjectService.prototype.create = async () => new UserProjectModel({})
+            UserProjectService.prototype.delete = async () => {}
+            return {}
+        },
+        template: '<UserTeam share-type="user" type="project" :id="1" />',
+    }),
+}

--- a/frontend/src/components/tasks/AddTask.stories.ts
+++ b/frontend/src/components/tasks/AddTask.stories.ts
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import AddTask from './AddTask.vue'
+import { useAuthStore } from '@/stores/auth'
+import { useTaskStore } from '@/stores/tasks'
+import TaskModel from '@/models/task'
+import type { ITask } from '@/modelTypes/ITask'
+
+const meta: Meta<typeof AddTask> = {
+    title: 'Tasks/AddTask',
+    component: AddTask,
+}
+export default meta
+
+type Story = StoryObj<typeof AddTask>
+
+export const Default: Story = {
+    render: () => ({
+        components: { AddTask },
+        setup() {
+            const authStore = useAuthStore()
+            Object.assign(authStore.settings, {
+                defaultProjectId: 1,
+                frontendSettings: { quickAddMagicMode: 'prefix' },
+            })
+
+            const taskStore = useTaskStore()
+            taskStore.isLoading.value = false
+            taskStore.ensureLabelsExist = async () => {}
+            taskStore.findProjectId = async () => 1
+            taskStore.createNewTask = async (data: Partial<ITask>) => new TaskModel({ id: Date.now(), ...data })
+            return {}
+        },
+        template: '<AddTask />',
+    }),
+}

--- a/frontend/src/components/tasks/GanttChart.stories.ts
+++ b/frontend/src/components/tasks/GanttChart.stories.ts
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import GanttChart from './GanttChart.vue'
+import TaskModel from '@/models/task'
+import type { GanttFilters } from '@/views/project/helpers/useGanttFilters'
+
+const meta: Meta<typeof GanttChart> = {
+    title: 'Tasks/GanttChart',
+    component: GanttChart,
+}
+export default meta
+
+type Story = StoryObj<typeof GanttChart>
+
+export const Default: Story = {
+    render: () => ({
+        components: { GanttChart },
+        setup() {
+            const filters: GanttFilters = {
+                projectId: 1,
+                viewId: 1,
+                dateFrom: new Date().toISOString(),
+                dateTo: new Date(Date.now() + 7 * 86400000).toISOString(),
+                showTasksWithoutDates: true,
+            }
+            const tasks = new Map<number, TaskModel>()
+            tasks.set(1, new TaskModel({ id: 1, title: 'Task 1', startDate: new Date(), endDate: new Date(Date.now() + 2 * 86400000) }))
+            tasks.set(2, new TaskModel({ id: 2, title: 'Task 2', startDate: new Date(Date.now() + 86400000), endDate: new Date(Date.now() + 5 * 86400000) }))
+            return { filters, tasks }
+        },
+        template: '<GanttChart :is-loading="false" :filters="filters" :tasks="tasks" default-task-start-date="1970-01-01" default-task-end-date="1970-01-01" />',
+    }),
+}

--- a/frontend/src/components/tasks/TaskForm.stories.ts
+++ b/frontend/src/components/tasks/TaskForm.stories.ts
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import TaskForm from './TaskForm.vue'
+
+const meta: Meta<typeof TaskForm> = {
+    title: 'Tasks/TaskForm',
+    component: TaskForm,
+}
+export default meta
+
+type Story = StoryObj<typeof TaskForm>
+
+export const Default: Story = {
+    render: () => ({
+        components: { TaskForm },
+        template: '<TaskForm />',
+    }),
+}

--- a/frontend/src/components/tasks/partials/AssigneeList.stories.ts
+++ b/frontend/src/components/tasks/partials/AssigneeList.stories.ts
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import AssigneeList from './AssigneeList.vue'
+import UserModel from '@/models/user'
+
+const meta: Meta<typeof AssigneeList> = {
+    title: 'Tasks/AssigneeList',
+    component: AssigneeList,
+}
+export default meta
+
+type Story = StoryObj<typeof AssigneeList>
+
+export const Default: Story = {
+    render: () => ({
+        components: { AssigneeList },
+        setup() {
+            const assignees = [
+                new UserModel({ id: 1, username: 'alice' }),
+                new UserModel({ id: 2, username: 'bob' }),
+            ]
+            return { assignees }
+        },
+        template: '<AssigneeList :assignees="assignees" />',
+    }),
+}

--- a/frontend/src/components/tasks/partials/Label.stories.ts
+++ b/frontend/src/components/tasks/partials/Label.stories.ts
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import Label from './Label.vue'
+import LabelModel from '@/models/label'
+
+const meta: Meta<typeof Label> = {
+    title: 'Tasks/Label',
+    component: Label,
+}
+export default meta
+
+type Story = StoryObj<typeof Label>
+
+export const Default: Story = {
+    render: () => ({
+        components: { Label },
+        setup() {
+            const label = new LabelModel({
+                id: 1,
+                title: 'Important',
+                hexColor: '#ffd700',
+                textColor: '#000000',
+            })
+            return { label }
+        },
+        template: '<Label :label="label" />',
+    }),
+}

--- a/frontend/src/components/tasks/partials/Labels.stories.ts
+++ b/frontend/src/components/tasks/partials/Labels.stories.ts
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import Labels from './Labels.vue'
+import LabelModel from '@/models/label'
+
+const meta: Meta<typeof Labels> = {
+    title: 'Tasks/Labels',
+    component: Labels,
+}
+export default meta
+
+type Story = StoryObj<typeof Labels>
+
+export const Default: Story = {
+    render: () => ({
+        components: { Labels },
+        setup() {
+            const labels = [
+                new LabelModel({ id: 1, title: 'Bug', hexColor: '#ff0000', textColor: '#ffffff' }),
+                new LabelModel({ id: 2, title: 'Feature', hexColor: '#00ff00', textColor: '#000000' }),
+            ]
+            return { labels }
+        },
+        template: '<Labels :labels="labels" />',
+    }),
+}

--- a/frontend/src/components/tasks/partials/PercentDoneSelect.stories.ts
+++ b/frontend/src/components/tasks/partials/PercentDoneSelect.stories.ts
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import PercentDoneSelect from './PercentDoneSelect.vue'
+import { ref } from 'vue'
+
+const meta: Meta<typeof PercentDoneSelect> = {
+    title: 'Tasks/PercentDoneSelect',
+    component: PercentDoneSelect,
+}
+export default meta
+
+type Story = StoryObj<typeof PercentDoneSelect>
+
+export const Default: Story = {
+    render: () => ({
+        components: { PercentDoneSelect },
+        setup() {
+            const percent = ref(0.3)
+            return { percent }
+        },
+        template: '<PercentDoneSelect v-model="percent" />',
+    }),
+}

--- a/frontend/src/components/tasks/partials/PriorityLabel.stories.ts
+++ b/frontend/src/components/tasks/partials/PriorityLabel.stories.ts
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import PriorityLabel from './PriorityLabel.vue'
+
+const meta: Meta<typeof PriorityLabel> = {
+    title: 'Tasks/PriorityLabel',
+    component: PriorityLabel,
+}
+export default meta
+
+type Story = StoryObj<typeof PriorityLabel>
+
+export const Default: Story = {
+    render: () => ({
+        components: { PriorityLabel },
+        template: '<PriorityLabel :priority="3" />',
+    }),
+}

--- a/frontend/src/components/tasks/partials/PrioritySelect.stories.ts
+++ b/frontend/src/components/tasks/partials/PrioritySelect.stories.ts
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import PrioritySelect from './PrioritySelect.vue'
+import { ref } from 'vue'
+
+const meta: Meta<typeof PrioritySelect> = {
+    title: 'Tasks/PrioritySelect',
+    component: PrioritySelect,
+}
+export default meta
+
+type Story = StoryObj<typeof PrioritySelect>
+
+export const Default: Story = {
+    render: () => ({
+        components: { PrioritySelect },
+        setup() {
+            const priority = ref(2)
+            return { priority }
+        },
+        template: '<PrioritySelect v-model="priority" />',
+    }),
+}


### PR DESCRIPTION
## Summary
- document AddTask, TaskForm and GanttChart in Storybook
- show QuickActions overlay in Storybook
- document sharing components (LinkSharing and UserTeam)

## Testing
- `pnpm --dir frontend lint`
- `pnpm --dir frontend typecheck` *(fails: existing type errors)*
- `pnpm --dir frontend exec vitest run --dir ./src`

------
https://chatgpt.com/codex/tasks/task_e_68501572e1388320b2a4e44bfb6ac38c