### PR TITLE
Add color scheme toggle button

### DIFF
--- a/frontend/src/components/home/AppHeader.vue
+++ b/frontend/src/components/home/AppHeader.vue
@@ -29,6 +29,7 @@
 				v-if="!isEditorContentEmpty(currentProject.description)"
 				:to="{ name: 'project.info', params: { projectId: currentProject.id } }"
 				class="project-title-button"
+				:aria-label="$t('project.description')"
 			>
 				<span class="tw-sr-only">{{ $t('project.description') }}</span>
 				<Icon icon="circle-info" />
@@ -42,6 +43,7 @@
 				<template #trigger="{ toggleOpen }">
 					<BaseButton
 						class="project-title-button"
+						:aria-label="$t('project.openSettingsMenu')"
 						@click="toggleOpen"
 					>
 						<span class="tw-sr-only">{{ $t('project.openSettingsMenu') }}</span>
@@ -57,6 +59,15 @@
 		<div class="navbar-end">
 			<OpenQuickActions />
 			<Notifications />
+			<BaseButton
+				variant="secondary"
+				:shadow="false"
+				class="color-scheme-toggle"
+				:aria-label="isDark ? $t('user.settings.appearance.colorScheme.light') : $t('user.settings.appearance.colorScheme.dark')"
+				@click="toggleColorScheme"
+			>
+				<Icon :icon="isDark ? 'sun' : ['far', 'moon']" />
+			</BaseButton>
 			<Dropdown>
 				<template #trigger="{ toggleOpen, open }">
 					<BaseButton
@@ -126,6 +137,7 @@ import Logo from '@/components/home/Logo.vue'
 import BaseButton from '@/components/base/BaseButton.vue'
 import MenuButton from '@/components/home/MenuButton.vue'
 import OpenQuickActions from '@/components/misc/OpenQuickActions.vue'
+import { useColorScheme } from '@/composables/useColorScheme'
 
 import { getProjectTitle } from '@/helpers/getProjectTitle'
 import { isEditorContentEmpty } from '@/helpers/editorContentEmpty'
@@ -141,10 +153,25 @@ const canWriteCurrentProject = computed(() => baseStore.currentProject?.maxRight
 const menuActive = computed(() => baseStore.menuActive)
 
 const authStore = useAuthStore()
+const { isDark } = useColorScheme()
 
 const configStore = useConfigStore()
 const imprintUrl = computed(() => configStore.legal.imprintUrl)
 const privacyPolicyUrl = computed(() => configStore.legal.privacyPolicyUrl)
+
+function toggleColorScheme() {
+        const newScheme = isDark.value ? 'light' : 'dark'
+        authStore.saveUserSettings({
+                settings: {
+                        ...authStore.settings,
+                        frontendSettings: {
+                                ...authStore.settings.frontendSettings,
+                                colorSchema: newScheme,
+                        },
+                },
+                showMessage: false,
+        })
+}
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/src/components/misc/Icon.ts
+++ b/frontend/src/components/misc/Icon.ts
@@ -81,17 +81,19 @@ import {
 	faX, faArrowTurnDown, faListCheck, faXmark, faXmarksLines, faFont, faRulerHorizontal, faUnderline,
 } from '@fortawesome/free-solid-svg-icons'
 import {
-	faBellSlash,
-	faCalendarAlt,
-	faCheckSquare,
-	faClock,
-	faComments,
-	faSave,
-	faSquareCheck,
-	faStar,
-	faSun,
-	faTimesCircle,
-	faCircleQuestion, faFaceLaugh,
+        faBellSlash,
+        faCalendarAlt,
+        faCheckSquare,
+        faClock,
+        faComments,
+        faSave,
+        faSquareCheck,
+        faStar,
+        faSun,
+        faMoon,
+        faTimesCircle,
+        faCircleQuestion,
+        faFaceLaugh,
 } from '@fortawesome/free-regular-svg-icons'
 import {FontAwesomeIcon} from '@fortawesome/vue-fontawesome'
 
@@ -173,6 +175,7 @@ library.add(faStar)
 library.add(faStarSolid)
 library.add(faStop)
 library.add(faSun)
+library.add(faMoon)
 library.add(faTachometerAlt)
 library.add(faTags)
 library.add(faTasks)


### PR DESCRIPTION
## Summary
- include moon icon in library
- add a header button to switch between dark and light modes
- ensure icon buttons in header have aria-labels

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: TS errors in existing files)*
- `pnpm test:unit` *(fails: exit code 130)*
- `pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_684a73c433688320ad32dce806be54db