### PR TITLE
Fix migration file descriptor leak

### DIFF
--- a/pkg/migration/20211212210054.go
+++ b/pkg/migration/20211212210054.go
@@ -65,6 +65,7 @@ func init() {
 				}
 
 				src, _, err := image.Decode(bgFile.File)
+				_ = bgFile.File.Close()
 				if err != nil && !errors.Is(err, image.ErrFormat) {
 					return err
 				}


### PR DESCRIPTION
## Summary
- close `bgFile.File` after decoding background images during migration

## Testing
- `mage lint`
- `mage build`
- `mage test:integration`
- `mage test:unit` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68502b3923d883208c0c0e7f67e58b54