### PR TITLE
Fix unsplash pingback HTTP response handling

### DIFF
--- a/pkg/modules/background/unsplash/unsplash.go
+++ b/pkg/modules/background/unsplash/unsplash.go
@@ -342,10 +342,16 @@ func pingbackByPhotoID(photoID string) {
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://views.unsplash.com/v?app_id="+config.BackgroundsUnsplashApplicationID.GetString()+"&photo_id="+photoID, nil)
 	if err != nil {
 		log.Errorf("Unsplash Pingback Failed: %s", err.Error())
+		return
 	}
-	_, err = http.DefaultClient.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		log.Errorf("Unsplash Pingback Failed: %s", err.Error())
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= 300 {
+		log.Errorf("Unsplash Pingback Failed: status code %d", resp.StatusCode)
 	}
 	log.Debugf("Pinged unsplash for photo %s", photoID)
 }


### PR DESCRIPTION
## Summary
- ensure pingback response body is properly closed
- warn when the pingback request doesn't return a 2xx status code

## Testing
- `mage lint`
- `mage test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68502b3a7e24832087356f70fbd359df