### PR TITLE
Ensure export file closed after download

### DIFF
--- a/pkg/routes/api/v1/user_export.go
+++ b/pkg/routes/api/v1/user_export.go
@@ -135,6 +135,11 @@ func DownloadUserDataExport(c echo.Context) error {
 	if err != nil {
 		return handler.HandleHTTPError(err)
 	}
+	defer func() {
+		if exportFile.File != nil {
+			_ = exportFile.File.Close()
+		}
+	}()
 
 	http.ServeContent(c.Response(), c.Request(), exportFile.Name, exportFile.Created, exportFile.File)
 	return nil


### PR DESCRIPTION
## Summary
- close `exportFile.File` after serving user export download

## Testing
- `mage lint`
- `mage test:unit`


------
https://chatgpt.com/codex/tasks/task_e_68502b359ab48320a1b23a6e29bfea8f