### PR TITLE
Fix export file not closed after creation

### DIFF
--- a/pkg/models/export.go
+++ b/pkg/models/export.go
@@ -105,6 +105,9 @@ func ExportUserData(s *xorm.Session, u *user.User) (err error) {
 		return err
 	}
 
+	// Close the reopened file after saving it in Vikunja
+	exported.Close()
+
 	// Save the file id with the user
 	u.ExportFileID = exportFile.ID
 	_, err = s.


### PR DESCRIPTION
## Summary
- close the reopened temporary file `exported` after calling `files.CreateWithMimeAndSession`

## Testing
- `mage test:unit`

------
https://chatgpt.com/codex/tasks/task_e_68502b39a08c8320ae73a217055747d3