### PR TITLE
fix: close task attachment file handle

### DIFF
--- a/pkg/routes/api/v1/task_attachment.go
+++ b/pkg/routes/api/v1/task_attachment.go
@@ -177,6 +177,7 @@ func GetTaskAttachment(c echo.Context) error {
 		_ = s.Rollback()
 		return handler.HandleHTTPError(err)
 	}
+	defer taskAttachment.File.File.Close()
 
 	if err := s.Commit(); err != nil {
 		_ = s.Rollback()


### PR DESCRIPTION
## Summary
- ensure task attachment file handle is closed

## Testing
- `mage lint`
- `mage test:unit`
- `mage test:integration`


------
https://chatgpt.com/codex/tasks/task_e_68502b381a5c8320bfe8737381955a82