### PR TITLE
fix missing close for project background file

### DIFF
--- a/pkg/modules/background/handler/background.go
+++ b/pkg/modules/background/handler/background.go
@@ -334,6 +334,7 @@ func GetProjectBackground(c echo.Context) error {
 		_ = s.Rollback()
 		return handler.HandleHTTPError(err)
 	}
+	defer bgFile.File.Close()
 	stat, err := bgFile.File.Stat()
 	if err != nil {
 		_ = s.Rollback()


### PR DESCRIPTION
## Summary
- close project background files after serving them

## Testing
- `mage test:unit` *(fails: signal interrupt)*
- `mage test:integration` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68502b37080c83209062684223a298f8