### PR TITLE
Fix node version setup in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,17 @@ on:
       - main
 
 jobs:
+  setup-node:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: frontend/.nvmrc
+
   test:
     name: Test
+    needs:
+      - setup-node
     uses: ./.github/workflows/test.yml
     secrets: inherit
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,7 +13,10 @@ For general information about the project, refer to the top-level readme of this
 
 ## Project setup
 
+Make sure you're using the Node version defined in `.nvmrc`:
+
 ```shell
+nvm install
 pnpm install
 ```
 


### PR DESCRIPTION
## Summary
- ensure GitHub CI installs the frontend's Node version
- document `nvm install` in frontend setup

## Testing
- `mage lint:fix`
- `pnpm lint:fix`

------
https://chatgpt.com/codex/tasks/task_e_68508e6582e883208568986554feb999