### PR TITLE
Update stories with overviews

### DIFF
--- a/frontend/src/components/base/BaseButton.stories.ts
+++ b/frontend/src/components/base/BaseButton.stories.ts
@@ -35,3 +35,15 @@ export const Disabled: Story = {
     }),
 }
 
+export const Overview: Story = {
+    render: () => ({
+        components: { BaseButton },
+        template: `
+            <div class="buttons">
+                <BaseButton>Default</BaseButton>
+                <BaseButton disabled>Disabled</BaseButton>
+            </div>
+        `,
+    }),
+}
+

--- a/frontend/src/components/input/Button.stories.ts
+++ b/frontend/src/components/input/Button.stories.ts
@@ -29,3 +29,16 @@ export const Tertiary: Story = {
         template: '<XButton variant="tertiary">Order tortellini!</XButton>',
     }),
 }
+
+export const Overview: Story = {
+    render: () => ({
+        components: { XButton },
+        template: `
+            <div class="buttons">
+                <XButton variant="primary">Primary</XButton>
+                <XButton variant="secondary">Secondary</XButton>
+                <XButton variant="tertiary">Tertiary</XButton>
+            </div>
+        `,
+    }),
+}

--- a/frontend/src/components/input/ColorPicker.stories.ts
+++ b/frontend/src/components/input/ColorPicker.stories.ts
@@ -20,3 +20,19 @@ export const Default: Story = {
         template: '<ColorPicker v-model="color" />',
     }),
 }
+
+export const Overview: Story = {
+    render: () => ({
+        components: { ColorPicker },
+        setup() {
+            const color = ref('#f2f2f2')
+            return { color }
+        },
+        template: `
+            <div class="field is-grouped">
+                <ColorPicker v-model="color" />
+                <ColorPicker v-model="color" disabled class="ml-2" />
+            </div>
+        `,
+    }),
+}

--- a/frontend/src/components/input/FancyCheckbox.stories.ts
+++ b/frontend/src/components/input/FancyCheckbox.stories.ts
@@ -53,3 +53,19 @@ export const UndefinedInitial: Story = {
         template: '<FancyCheckbox v-model="withoutInitialState">Not sure what the value should be</FancyCheckbox>\n<input v-model="withoutInitialState" type="checkbox" disabled> {{ withoutInitialState }}',
     }),
 }
+
+export const Overview: Story = {
+    render: () => ({
+        components: { FancyCheckbox },
+        setup() {
+            const model = ref(false)
+            return { model }
+        },
+        template: `
+            <div>
+                <FancyCheckbox v-model="model">Default</FancyCheckbox>
+                <FancyCheckbox v-model="model" disabled class="ml-2">Disabled</FancyCheckbox>
+            </div>
+        `,
+    }),
+}

--- a/frontend/src/components/misc/Modal.stories.ts
+++ b/frontend/src/components/misc/Modal.stories.ts
@@ -11,11 +11,11 @@ export default meta
 
 type Story = StoryObj<typeof Modal>
 
-export const Default: Story = {
+export const Overview: Story = {
     render: () => ({
         components: { Modal, BaseButton },
         setup() {
-            const open = ref(true)
+            const open = ref(false)
             return { open }
         },
         template: `

--- a/frontend/src/views/404.stories.ts
+++ b/frontend/src/views/404.stories.ts
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import NotFound from './404.vue'
+
+const meta: Meta<typeof NotFound> = {
+    title: 'Views/404',
+    component: NotFound,
+}
+export default meta
+
+type Story = StoryObj<typeof NotFound>
+
+export const Overview: Story = {
+    render: () => ({
+        components: { NotFound },
+        template: '<NotFound />',
+    }),
+}

--- a/frontend/src/views/About.stories.ts
+++ b/frontend/src/views/About.stories.ts
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import About from './About.vue'
+import { useConfigStore } from '@/stores/config'
+
+const meta: Meta<typeof About> = {
+    title: 'Views/About',
+    component: About,
+}
+export default meta
+
+type Story = StoryObj<typeof About>
+
+export const Overview: Story = {
+    render: () => ({
+        components: { About },
+        setup() {
+            const configStore = useConfigStore()
+            configStore.version = 'v1.0.0'
+            return {}
+        },
+        template: '<About />',
+    }),
+}


### PR DESCRIPTION
## Summary
- showcase primary and disabled states in BaseButton stories
- demonstrate button variants together in an overview
- add FancyCheckbox overview with enabled and disabled options
- show ColorPicker enabled/disabled examples
- open and close modal in a single overview
- add Storybook stories for the About and 404 views
- refine Modal story to start closed

## Testing
- `pnpm lint:fix`


------
https://chatgpt.com/codex/tasks/task_e_68508fd72a248320b684ea08aed4c6f0