### PR TITLE
Improve CI caching for e2e

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -325,6 +325,8 @@ jobs:
           browser: chrome
           record: true
           parallel: true
+          install: false
+          cache-key: cypress-${{ runner.os }}-${{ hashFiles('frontend/pnpm-lock.yaml') }}
           start: |
             pnpm run preview:vikunja
             pnpm run preview


### PR DESCRIPTION
## Summary
- cache Cypress binaries across e2e containers
- avoid reinstalling dependencies when running Cypress

## Testing
- `pnpm --dir frontend lint`
- `pnpm --dir frontend typecheck` *(fails: cannot find name 'ImportMetaEnv', plus many others)*

------
https://chatgpt.com/codex/tasks/task_e_68510643d18883208043540d3f4b60b9