### PR TITLE
Add manual site monitor trigger and store Lighthouse reports

### DIFF
--- a/.github/workflows/site-monitor.yml
+++ b/.github/workflows/site-monitor.yml
@@ -1,0 +1,36 @@
+name: Site Monitor
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+      timezone: 'UTC'
+  workflow_dispatch:
+
+jobs:
+  lighthouse:
+    name: Lighthouse audits
+    runs-on: ubuntu-latest
+    env:
+      DO_NOT_TRACK: '1'
+    steps:
+      - name: Run Lighthouse
+        uses: treosh/lighthouse-ci-action@72f881228236981b625ed765b928efb1786a1f55 # v11
+        with:
+          urls: https://try.vikunja.io/
+      - name: Upload Lighthouse report
+        uses: actions/upload-artifact@v4
+        with:
+          name: lighthouse-report
+          path: .lighthouseci
+
+  uptime:
+    name: Uptime check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check uptime
+        uses: Jtalk/url-health-check-action@b716ccb6645355dd9fcce8002ce460e5474f7f00 # v1.8
+        with:
+          url: https://try.vikunja.io/api/v1/info
+          expected-status: '200'
+          max-attempts: 3
+          retry-delay: 5s

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ try it on [try.vikunja.io](https://try.vikunja.io)!
 * [Development setup](https://vikunja.io/docs/development/)
 * [Magefile](https://vikunja.io/docs/magefile/)
 * [Testing](https://vikunja.io/docs/testing/)
+* Scheduled [Lighthouse](https://github.com/GoogleChrome/lighthouse) audits and uptime checks keep [try.vikunja.io](https://try.vikunja.io) healthy.
 
 All docs can be found on [the Vikunja home page](https://vikunja.io/docs/).
 


### PR DESCRIPTION
## Summary
- improve site-monitor workflow
  - add manual trigger and UTC timezone
  - upload Lighthouse reports and disable telemetry
  - name workflow jobs and validate uptime status
- document scheduled checks in the README

## Testing
- `mage lint`
- `mage build`
- `VIKUNJA_SERVICE_ROOTPATH=$(pwd) mage test:unit`
- `VIKUNJA_SERVICE_ROOTPATH=$(pwd) mage test:integration`
- `pnpm --dir frontend install --frozen-lockfile`
- `pnpm --dir frontend lint`
- `pnpm --dir frontend typecheck` *(fails: src/views/user/settings/*)*
- `pnpm --dir frontend test:unit --run`


------
https://chatgpt.com/codex/tasks/task_e_6850a6a2f8f08320ab45231e925b3695