### PR TITLE
docs: clarify secret placeholders

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -314,10 +314,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           CYPRESS_API_URL: http://127.0.0.1:3456/api/v1
-          CYPRESS_TEST_SECRET: averyLongSecretToSe33dtheDB
+          # Test tokens should come from GitHub secrets
+          CYPRESS_TEST_SECRET: ${{ secrets.CYPRESS_TEST_SECRET }}
           CYPRESS_DEFAULT_COMMAND_TIMEOUT: 60000
           CYPRESS_CI_BUILD_ID: '${{ github.workflow }}-${{ github.run_id }}-${{ github.run_attempt }}' # see https://github.com/cypress-io/github-action/issues/431
-          VIKUNJA_SERVICE_TESTINGTOKEN: averyLongSecretToSe33dtheDB
+          VIKUNJA_SERVICE_TESTINGTOKEN: ${{ secrets.VIKUNJA_SERVICE_TESTINGTOKEN }}
           VIKUNJA_LOG_LEVEL: DEBUG
           VIKUNJA_CORS_ENABLE: 1
           VIKUNJA_DATABASE_PATH: memory

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,12 +1,12 @@
 # (1) Duplicate this file and remove the '.example' suffix.
 # Naming this file '.env.local' is a Vite convention to prevent accidentally
-# submitting to git.
+# submitting it to git. Never commit secrets.
 # For more info see: https://vitejs.dev/guide/env-and-mode.html#env-files
 
 # (2) Comment in and adjust the values as needed.
 
 # VITE_IS_ONLINE=true
-# SENTRY_AUTH_TOKEN=YOUR_TOKEN
+# SENTRY_AUTH_TOKEN=<sentry-auth-token>
 # SENTRY_ORG=vikunja
 # SENTRY_PROJECT=frontend-oss
 # VIKUNJA_FRONTEND_BASE=/custom-subpath

--- a/frontend/cypress.config.ts
+++ b/frontend/cypress.config.ts
@@ -1,10 +1,12 @@
 import {defineConfig} from 'cypress'
 
 export default defineConfig({
-	env: {
-		API_URL: 'http://localhost:3456/api/v1',
-		TEST_SECRET: 'averyLongSecretToSe33dtheDB',
-	},
+       env: {
+               API_URL: 'http://localhost:3456/api/v1',
+               // Set this token via the CYPRESS_TEST_SECRET env var.
+               // Never commit a real testing token here.
+               TEST_SECRET: process.env.CYPRESS_TEST_SECRET ?? '<testing-secret>',
+       },
 	video: false,
 	retries: {
 		runMode: 2,

--- a/frontend/cypress/README.md
+++ b/frontend/cypress/README.md
@@ -2,10 +2,11 @@
 
 ## Setup
 
-* Enable the [seeder api endpoint](https://vikunja.io/docs/config-options/#testingtoken). You'll then need to add the testingtoken in `cypress.json` or set the `CYPRESS_TEST_SECRET` environment variable.
+* Enable the [seeder api endpoint](https://vikunja.io/docs/config-options/#testingtoken). You'll then need to add the testing token in `cypress.json` or set the `CYPRESS_TEST_SECRET` environment variable.
 * Basic configuration happens in the `cypress.json` file
 * Overridable with [env](https://docs.cypress.io/guides/guides/environment-variables.html#Option-3-CYPRESS)
 * Override base url with `CYPRESS_BASE_URL`
+* **Never commit real tokens**. Provide them through environment variables or an `.env` file which is gitignored.
 
 ## Fixtures
 

--- a/frontend/cypress/docker-compose.yml
+++ b/frontend/cypress/docker-compose.yml
@@ -5,7 +5,8 @@ services:
     image: vikunja/api:unstable@sha256:61b77af0f0ed5b0e4c3ee693a79926d8633712ddb245f8212ba5e5321485d330
     environment:
       VIKUNJA_LOG_LEVEL: DEBUG
-      VIKUNJA_SERVICE_TESTINGTOKEN: averyLongSecretToSe33dtheDB
+      # Replace with your own testing token via environment variable
+      VIKUNJA_SERVICE_TESTINGTOKEN: ${VIKUNJA_SERVICE_TESTINGTOKEN:-<testing-token>}
     ports:
       - 3456:3456
   cypress:
@@ -17,4 +18,5 @@ services:
     working_dir: /project
     environment:
       CYPRESS_API_URL: http://api:3456/api/v1
-      CYPRESS_TEST_SECRET: averyLongSecretToSe33dtheDB
+      # Provide the secret via CYPRESS_TEST_SECRET env var when running tests
+      CYPRESS_TEST_SECRET: ${CYPRESS_TEST_SECRET:-<testing-secret>}


### PR DESCRIPTION
## Summary
- clean up leftover secrets in docs and configs
- document that test tokens should not be committed
- encourage using env vars
- use GitHub secrets in CI workflow

## Testing
- `pnpm lint:fix`
- `mage lint:fix` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68512d345344832096a19b41ce66f7fa