### PR TITLE
Improve getInheritedBackgroundColor helper

### DIFF
--- a/BACKGROUND_COLOR_FOLLOWUP.txt
+++ b/BACKGROUND_COLOR_FOLLOWUP.txt
@@ -1,0 +1,3 @@
+- Consider migrating to the CSS Typed OM API for more robust color comparisons.
+- Expose a CSS custom property for the application background and read that instead of walking the DOM.
+- Revisit the unit tests once other modules are TypeScript error free so `pnpm typecheck` passes cleanly.

--- a/frontend/src/helpers/getInheritedBackgroundColor.test.ts
+++ b/frontend/src/helpers/getInheritedBackgroundColor.test.ts
@@ -1,0 +1,40 @@
+import {describe, expect, it} from 'vitest'
+import {getInheritedBackgroundColor} from './getInheritedBackgroundColor'
+
+describe('getInheritedBackgroundColor', () => {
+	it('returns the element\'s background color', () => {
+		const el = document.createElement('div')
+		el.style.backgroundColor = 'rgb(255, 0, 0)'
+		document.body.appendChild(el)
+
+		const result = getInheritedBackgroundColor(el)
+
+		document.body.removeChild(el)
+		expect(result).toBe('rgb(255, 0, 0)')
+	})
+
+	it('gets color from parent when element is transparent', () => {
+		const parent = document.createElement('div')
+		parent.style.backgroundColor = 'rgb(0, 255, 0)'
+		const child = document.createElement('div')
+		child.style.backgroundColor = 'rgba(0, 0, 0, 0)'
+		parent.appendChild(child)
+		document.body.appendChild(parent)
+
+		const result = getInheritedBackgroundColor(child)
+
+		document.body.removeChild(parent)
+		expect(result).toBe('rgb(0, 255, 0)')
+	})
+
+	it('falls back to document background when none found', () => {
+		const el = document.createElement('div')
+		document.body.appendChild(el)
+		const defaultBg = getComputedStyle(document.documentElement).backgroundColor
+
+		const result = getInheritedBackgroundColor(el)
+
+		document.body.removeChild(el)
+		expect(result).toBe(defaultBg)
+	})
+})

--- a/frontend/src/helpers/getInheritedBackgroundColor.ts
+++ b/frontend/src/helpers/getInheritedBackgroundColor.ts
@@ -1,24 +1,48 @@
-function getDefaultBackground() {
-  const div = document.createElement('div')
-  document.head.appendChild(div)
-  const bg = window.getComputedStyle(div).backgroundColor
-  document.head.removeChild(div)
-  return bg
+/**
+ * Get the browser’s default background color (usually transparent).
+ * We only call this once, so we avoid inserting dummy elements or
+ * recomputing on every iteration.
+ */
+function getDefaultBG(): string {
+	return getComputedStyle(document.documentElement).backgroundColor
 }
 
-// get default style for current browser
-const defaultStyle = getDefaultBackground() // typically "rgba(0, 0, 0, 0)"
+/**
+ * Normalize “transparent” values:
+ *	 • keyword "transparent"
+ *	 • rgba(0, 0, 0, 0)
+ */
+function isTransparent(color: string): boolean {
+	return color === 'transparent'
+		|| color === 'rgba(0, 0, 0, 0)'
+}
 
-// based on https://stackoverflow.com/a/62630563/15522256
-export function getInheritedBackgroundColor(el: HTMLElement): string {  
-  const backgroundColor = window.getComputedStyle(el).backgroundColor
+/**
+ * Walks up the DOM from `el` until we find a non-default background.
+ *
+ * Notes / Future ideas:
+ *	  • We could migrate to the CSS Typed OM API to get typed
+ *		color values (no string parsing, better comparisons).
+ *	  • Alternatively, lean on the cascade by tracking your page’s
+ *		background in a CSS custom‐property (e.g. “--bg”) and simply
+ *		read that—no tree-walking needed.
+ */
+export function getInheritedBackgroundColor(el: HTMLElement): string {
+	const DEFAULT_BG = getDefaultBG()
 
-  if (backgroundColor !== defaultStyle) return backgroundColor
+	let curr: HTMLElement | null = el
+	while (curr) {
+		// Only compute when we actually need to check this element
+		const bg = getComputedStyle(curr).backgroundColor
 
-  if (!el.parentElement) {
-		// we reached the top parent el without getting an explicit color
-		return defaultStyle
+		// If it’s neither the default nor transparent, that’s our answer
+		if (!isTransparent(bg) && bg !== DEFAULT_BG) {
+			return bg
+		}
+
+		curr = curr.parentElement
 	}
-  
-  return getInheritedBackgroundColor(el.parentElement)
+
+	// Fell off the top: use whatever the default is
+	return DEFAULT_BG
 }


### PR DESCRIPTION
## Summary
- use a DOM walk to detect inherited backgrounds
- add unit tests for getInheritedBackgroundColor
- note possible follow-up improvements

## Testing
- `pnpm --dir frontend lint`
- `pnpm --dir frontend typecheck` *(fails: numerous existing errors)*
- `pnpm --dir frontend exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6851821188c48320be72c77d46a5d003