### PR TITLE
Fix typo in Kanban bucket position comment

### DIFF
--- a/frontend/src/components/project/views/ProjectKanban.vue
+++ b/frontend/src/components/project/views/ProjectKanban.vue
@@ -665,7 +665,7 @@ function updateBuckets(value: IBucket[]) {
 
 // TODO: fix type
 function updateBucketPosition(e: { newIndex: number }) {
-	// (2) bucket positon is changed
+       // (2) bucket position is changed
 	dragBucket.value = false
 
 	const bucket = buckets.value[e.newIndex]


### PR DESCRIPTION
## Summary
- fix comment in `ProjectKanban.vue`

## Testing
- `pnpm --dir frontend lint`


------
https://chatgpt.com/codex/tasks/task_e_68518e03134c8320ab89215e24527b0e