### PR TITLE
Document repo structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,35 @@ All docs can be found on [the Vikunja home page](https://vikunja.io/docs/).
 
 See [the roadmap](https://my.vikunja.cloud/share/QFyzYEmEYfSyQfTOmIRSwLUpkFjboaBqQCnaPmWd/auth) (hosted on Vikunja!) for more!
 
+## Components
+
+The project is split into three main parts:
+
+| Component | Location | Description |
+|-----------|----------|-------------|
+| API | `pkg/` and `main.go` | Go backend providing the REST API and serving the built frontend. |
+| Web frontend | `frontend/` | Vue.js single page application bundled into static files. |
+| Desktop app | `desktop/` | Electron wrapper shipping the frontend for desktop users. |
+
+```
+ +-------+      +-----------+      +------------+
+ |  API  | <--> | Frontend  | <--> |  Desktop   |
+ +-------+      +-----------+      +------------+
+```
+
+## Repository Structure
+
+| Directory | Purpose |
+|-----------|---------|
+| `build/` | Packaging and release helpers. |
+| `contrib/` | Additional tooling and scripts. |
+| `desktop/` | Electron desktop wrapper for Vikunja. |
+| `frontend/` | Web frontend source code. |
+| `pkg/` | Go packages implementing the API. |
+| `rest/` | Example API requests for testing. |
+| `scripts/` | Development and CI helper scripts. |
+| `.github/` | GitHub workflow configuration. |
+
 ## Contributing
 
 Please check out the contribution guidelines on [the website](https://vikunja.io/docs/development/).

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -4,6 +4,9 @@
 
 The Vikunja frontend all repackaged as an electron app to run as a desktop app!
 
+It uses the built files from `../frontend` and wraps them with Electron so the
+Vikunja web interface can be run as a native application.
+
 ## Dev
 
 As this package does not contain any code, only a thin wrapper around electron, you will need to do this to get the 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,6 +7,9 @@
 
 This is the web frontend for Vikunja, written in Vue.js.
 
+It lives inside the main Vikunja repository. When you build the API one level
+up, the compiled files from this directory are served as the web interface.
+
 Take a look at [our roadmap](https://my.vikunja.cloud/share/UrdhKPqumxDXUbYpEGJLSIyNTwAnbBzVlwdDpRbv/auth) (hosted on Vikunja!) for a list of things we're currently working on!
 
 For general information about the project, refer to the top-level readme of this repo.

--- a/rest/README.md
+++ b/rest/README.md
@@ -1,0 +1,6 @@
+# REST examples
+
+This folder contains sample requests for the Vikunja API. The collection is
+made for the [Bruno](https://www.usebruno.com/) REST client and lets you try the
+endpoints against a running Vikunja instance.
+


### PR DESCRIPTION
## Summary
- add project components and repository structure to README
- crosslink frontend and desktop packages to the API
- add README to REST examples

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851b64643788320a5252c1c6508d02e