### PR TITLE
Add Cypress cache note

### DIFF
--- a/Cypress-single-test-notes.md
+++ b/Cypress-single-test-notes.md
@@ -38,3 +38,9 @@ This documents troubleshooting steps when running Cypress locally.
 
 If Chrome is missing, the command will fail. After the run, stop the API and preview processes with `kill %1`.
 If the test fails, check `/tmp/cypress.log` for details.
+
+## Ensure a fresh binary cache
+
+```bash
+npx --no-install cypress cache clear
+```


### PR DESCRIPTION
## Summary
- update Cypress single test notes with cache clearing instructions

## Testing
- `pnpm --dir frontend lint`
- `pnpm --dir frontend typecheck` *(fails: many existing TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68528041b1688320bbf3e4c13d98fa36