### PR TITLE
Add summary docs for composable gantt

### DIFF
--- a/gantt_docs/index.md
+++ b/gantt_docs/index.md
@@ -1,0 +1,17 @@
+# Composable Gantt Concept Overview
+
+This directory hosts summary documents for each project phase and implementation step referenced in `COMPOSABLE_GANTT.md`.
+
+## Phases
+- [Phase 1: Landscape & Style Research](phase1_landscape_style_research.md)
+- [Phase 2: API & Architecture Design](phase2_api_architecture_design.md)
+- [Phase 3: Implementation & Infrastructure](phase3_implementation_infrastructure.md)
+- [Phase 4: Testing & Quality](phase4_testing_quality.md)
+- [Phase 5: Documentation & Distribution](phase5_documentation_distribution.md)
+
+## Implementation Steps
+- [Step 1: Project Setup](step1_project_setup.md)
+- [Step 2: Accessibility & Keyboard Support](step2_accessibility_keyboard_support.md)
+- [Step 3: Customization & Extensibility](step3_customization_extensibility.md)
+- [Step 4: Documentation & Examples](step4_documentation_examples.md)
+- [Step 5: Testing & CI](step5_testing_ci.md)

--- a/gantt_docs/phase1_landscape_style_research.md
+++ b/gantt_docs/phase1_landscape_style_research.md
@@ -1,0 +1,11 @@
+# Phase 1: Landscape & Style Research
+
+This phase focuses on exploring best practices for headless component design and styling conventions. Key points from `COMPOSABLE_GANTT.md` include:
+
+- Study Headless UI primitives and accessibility model.
+- Review VueUse composable guidelines covering option objects, reactivity, and `isSupported` flags.
+- Analyze Reka UI's class-through APIs and WAI-ARIA compliance.
+- Inspect vue-ganttastic to understand its API surface and slot usage.
+
+## Task
+- Expand this document with deeper research from `COMPOSABLE_GANTT.md` and other sources, detailing specific takeaways and references for each bullet point.

--- a/gantt_docs/phase2_api_architecture_design.md
+++ b/gantt_docs/phase2_api_architecture_design.md
@@ -1,0 +1,11 @@
+# Phase 2: API & Architecture Design
+
+In this phase the project defines the core composables and renderless components. Highlights from `COMPOSABLE_GANTT.md`:
+
+- Draft composables such as `useGantt` alongside `<GanttChart>` and `<GanttRow>` primitives.
+- Specify props and slots for start and end dates, precision, and event callbacks.
+- Outline headless primitives for time-scale generation, bar management, pointer events, and keyboard interactions.
+- Plan TypeScript definitions and JSDoc comments for full IDE support.
+
+## Task
+- Produce a more detailed design document using `COMPOSABLE_GANTT.md` as the primary reference, expanding on component APIs and architectural diagrams.

--- a/gantt_docs/phase3_implementation_infrastructure.md
+++ b/gantt_docs/phase3_implementation_infrastructure.md
@@ -1,0 +1,11 @@
+# Phase 3: Implementation & Infrastructure
+
+`COMPOSABLE_GANTT.md` outlines the tooling and project structure for building the library:
+
+- Use Vite with TypeScript and Vue 3 alongside Vitest and Playwright.
+- Organize code under `src/composables/`, `src/components/`, `src/hooks/`, `src/utils/`, and `src/styles/` (initially empty).
+- Follow VueUse patterns such as `configurableWindow`, `tryOnUnmounted`, and `isSupported` flags.
+- Provide ARIA roles, keyboard navigation, and unstyled outputs with data-state attributes for styling.
+
+## Task
+- Expand on build tools, directory conventions, and accessibility patterns using `COMPOSABLE_GANTT.md` and additional references.

--- a/gantt_docs/phase4_testing_quality.md
+++ b/gantt_docs/phase4_testing_quality.md
@@ -1,0 +1,11 @@
+# Phase 4: Testing & Quality
+
+Testing and quality assurance goals from `COMPOSABLE_GANTT.md`:
+
+- Unit test composables with Vitest.
+- End-to-end tests for interactive behavior using Playwright.
+- Apply ESLint, Prettier, and TypeScript rules following the Vue style guide.
+- Configure GitHub Actions for build, test, and publishing workflows.
+
+## Task
+- Build out a complete testing strategy referencing `COMPOSABLE_GANTT.md` and other resources on Vue testing best practices.

--- a/gantt_docs/phase5_documentation_distribution.md
+++ b/gantt_docs/phase5_documentation_distribution.md
@@ -1,0 +1,11 @@
+# Phase 5: Documentation & Distribution
+
+The final phase covers how to document and ship the library. Notes from `COMPOSABLE_GANTT.md`:
+
+- Create interactive docs with VitePress and VueUse-style demos.
+- Provide Storybook stories for each primitive and composed component.
+- Publish the package to npm with side‑effect‑free entrypoints and type declarations.
+- Follow semantic versioning with a CHANGELOG and a migration guide from vue-ganttastic.
+
+## Task
+- Elaborate on distribution workflow and documentation site structure using information from `COMPOSABLE_GANTT.md` and related resources.

--- a/gantt_docs/step1_project_setup.md
+++ b/gantt_docs/step1_project_setup.md
@@ -1,0 +1,10 @@
+# Implementation Step 1: Project Setup
+
+From the implementation concept derived from `COMPOSABLE_GANTT.md`:
+
+- Bootstrap a new package using Vite, TypeScript, and Vue 3.
+- Implement a core composable `useGantt` and headless primitives `<GanttChartPrimitive>` and `<GanttRowPrimitive>`.
+- Keep the library unstyled so integrators can apply their own classes or Tailwind utilities.
+
+## Task
+- Extend this setup guide with concrete initialization commands and folder layouts, citing `COMPOSABLE_GANTT.md` along with other setup best practices.

--- a/gantt_docs/step2_accessibility_keyboard_support.md
+++ b/gantt_docs/step2_accessibility_keyboard_support.md
@@ -1,0 +1,10 @@
+# Implementation Step 2: Accessibility and Keyboard Support
+
+Based on the concept and `COMPOSABLE_GANTT.md`:
+
+- Follow the ARIA grid pattern for keyboard navigation (arrow keys, home/end, page navigation).
+- Expose `aria-selected` and `data-state="selected"` attributes for styling and accessibility.
+- Handle focus management and outside-click deselection using VueUse's `onClickOutside`.
+
+## Task
+- Develop a comprehensive accessibility guide referencing `COMPOSABLE_GANTT.md` and WAI-ARIA resources, covering all keyboard interactions and ARIA roles.

--- a/gantt_docs/step3_customization_extensibility.md
+++ b/gantt_docs/step3_customization_extensibility.md
@@ -1,0 +1,10 @@
+# Implementation Step 3: Customization and Extensibility
+
+This step ensures that users can extend the library. Notes from `COMPOSABLE_GANTT.md` and the concept include:
+
+- Expose configuration options via composables, e.g., `useGantt({ start, end, precision })`.
+- Provide optional Tailwind-based wrappers for quicker styling.
+- Keep primitives headless so custom styles and behaviors can be layered on top.
+
+## Task
+- Write an extended customization guide referencing `COMPOSABLE_GANTT.md` and other libraries that support composable customization.

--- a/gantt_docs/step4_documentation_examples.md
+++ b/gantt_docs/step4_documentation_examples.md
@@ -1,0 +1,10 @@
+# Implementation Step 4: Documentation & Examples
+
+As suggested by the concept and `COMPOSABLE_GANTT.md`:
+
+- Use Storybook to showcase selection and keyboard behavior.
+- Document API props, events, and slots, including the rationale from the design file.
+- Provide example integrations demonstrating selection, drag-and-drop, and styling via data attributes.
+
+## Task
+- Create an expanded documentation plan referencing `COMPOSABLE_GANTT.md` and existing Storybook/VitePress setups.

--- a/gantt_docs/step5_testing_ci.md
+++ b/gantt_docs/step5_testing_ci.md
@@ -1,0 +1,10 @@
+# Implementation Step 5: Testing & CI
+
+Implementation also calls for automated checks:
+
+- Create unit tests with Vitest and integration tests with Playwright.
+- Integrate linting, testing, and build steps into GitHub Actions.
+- Ensure keyboard interactions and accessibility states are tested.
+
+## Task
+- Provide a full CI configuration outline using `COMPOSABLE_GANTT.md` as a starting point and referencing common GitHub Actions patterns.


### PR DESCRIPTION
## Summary
- document each phase from `COMPOSABLE_GANTT.md`
- record steps from the implementation concept
- link all docs in a new index file

## Testing
- `pnpm --dir frontend lint`
- `pnpm --dir frontend typecheck` *(fails: existing type errors in untouched files)*
- `mage lint`


------
https://chatgpt.com/codex/tasks/task_e_685326262a4c8320b03fe0b16b35983a