### PR TITLE
Add index links to phase docs

### DIFF
--- a/gantt_docs/phase1_landscape_style_research.md
+++ b/gantt_docs/phase1_landscape_style_research.md
@@ -9,3 +9,5 @@ This phase focuses on exploring best practices for headless component design and
 
 ## Task
 - Expand this document with deeper research from `COMPOSABLE_GANTT.md` and other sources, detailing specific takeaways and references for each bullet point.
+
+Back to [index](index.md)

--- a/gantt_docs/phase2_api_architecture_design.md
+++ b/gantt_docs/phase2_api_architecture_design.md
@@ -9,3 +9,5 @@ In this phase the project defines the core composables and renderless components
 
 ## Task
 - Produce a more detailed design document using `COMPOSABLE_GANTT.md` as the primary reference, expanding on component APIs and architectural diagrams.
+
+Back to [index](index.md)

--- a/gantt_docs/phase3_implementation_infrastructure.md
+++ b/gantt_docs/phase3_implementation_infrastructure.md
@@ -9,3 +9,5 @@
 
 ## Task
 - Expand on build tools, directory conventions, and accessibility patterns using `COMPOSABLE_GANTT.md` and additional references.
+
+Back to [index](index.md)

--- a/gantt_docs/phase4_testing_quality.md
+++ b/gantt_docs/phase4_testing_quality.md
@@ -9,3 +9,5 @@ Testing and quality assurance goals from `COMPOSABLE_GANTT.md`:
 
 ## Task
 - Build out a complete testing strategy referencing `COMPOSABLE_GANTT.md` and other resources on Vue testing best practices.
+
+Back to [index](index.md)

--- a/gantt_docs/phase5_documentation_distribution.md
+++ b/gantt_docs/phase5_documentation_distribution.md
@@ -9,3 +9,5 @@ The final phase covers how to document and ship the library. Notes from `COMPOSA
 
 ## Task
 - Elaborate on distribution workflow and documentation site structure using information from `COMPOSABLE_GANTT.md` and related resources.
+
+Back to [index](index.md)


### PR DESCRIPTION
## Summary
- link each project phase doc back to the index

## Testing
- `mage test:unit`
- `mage test:integration`


------
https://chatgpt.com/codex/tasks/task_e_6853415069c4832099f5c30bb04ea31e