### PR TITLE
Add footer links back to index

### DIFF
--- a/gantt_docs/step1_project_setup.md
+++ b/gantt_docs/step1_project_setup.md
@@ -8,3 +8,5 @@ From the implementation concept derived from `COMPOSABLE_GANTT.md`:
 
 ## Task
 - Extend this setup guide with concrete initialization commands and folder layouts, citing `COMPOSABLE_GANTT.md` along with other setup best practices.
+
+Back to [index](index.md)

--- a/gantt_docs/step2_accessibility_keyboard_support.md
+++ b/gantt_docs/step2_accessibility_keyboard_support.md
@@ -8,3 +8,5 @@ Based on the concept and `COMPOSABLE_GANTT.md`:
 
 ## Task
 - Develop a comprehensive accessibility guide referencing `COMPOSABLE_GANTT.md` and WAI-ARIA resources, covering all keyboard interactions and ARIA roles.
+
+Back to [index](index.md)

--- a/gantt_docs/step3_customization_extensibility.md
+++ b/gantt_docs/step3_customization_extensibility.md
@@ -8,3 +8,5 @@ This step ensures that users can extend the library. Notes from `COMPOSABLE_GANT
 
 ## Task
 - Write an extended customization guide referencing `COMPOSABLE_GANTT.md` and other libraries that support composable customization.
+
+Back to [index](index.md)

--- a/gantt_docs/step4_documentation_examples.md
+++ b/gantt_docs/step4_documentation_examples.md
@@ -8,3 +8,5 @@ As suggested by the concept and `COMPOSABLE_GANTT.md`:
 
 ## Task
 - Create an expanded documentation plan referencing `COMPOSABLE_GANTT.md` and existing Storybook/VitePress setups.
+
+Back to [index](index.md)

--- a/gantt_docs/step5_testing_ci.md
+++ b/gantt_docs/step5_testing_ci.md
@@ -8,3 +8,5 @@ Implementation also calls for automated checks:
 
 ## Task
 - Provide a full CI configuration outline using `COMPOSABLE_GANTT.md` as a starting point and referencing common GitHub Actions patterns.
+
+Back to [index](index.md)


### PR DESCRIPTION
## Summary
- link from each implementation step back to the index

## Testing
- `pnpm --dir frontend lint`
- `pnpm --dir frontend typecheck` *(fails: numerous type errors in unrelated files)*
- `mage test:unit`
- `mage test:integration`


------
https://chatgpt.com/codex/tasks/task_e_68534b2156d48320b242ce8478d843ca