### PR TITLE
docs: detail aria roles and examples

### DIFF
--- a/gantt_docs/step2_accessibility_keyboard_support.md
+++ b/gantt_docs/step2_accessibility_keyboard_support.md
@@ -5,6 +5,38 @@ Based on the concept and `COMPOSABLE_GANTT.md`:
 - Follow the ARIA grid pattern for keyboard navigation (arrow keys, home/end, page navigation).
 - Expose `aria-selected` and `data-state="selected"` attributes for styling and accessibility.
 - Handle focus management and outside-click deselection using VueUse's `onClickOutside`.
+- Use explicit roles on each element:
+  - `role="grid"` on the chart container with `tabindex="0"` for initial focus.
+  - `role="row"` on row groups and `role="gridcell"` on each bar container.
+  - Manage active cells via `aria-activedescendant` or `tabindex` handling.
+  - Optionally set `aria-colindex`, `aria-rowindex` and `aria-disabled` for stateful bars.
+
+### Example markup
+
+```vue
+<GanttChartPrimitive
+    role="grid"
+    tabindex="0"
+    @keydown="onGridKeydown"
+>
+    <g role="row" v-for="(row, rowIndex) in rows" :key="row.id">
+        <g
+            role="gridcell"
+            :aria-colindex="bar.col"
+            :aria-rowindex="rowIndex + 1"
+            :aria-selected="isSelected(bar)"
+            :data-state="isSelected(bar) ? 'selected' : undefined"
+            tabindex="-1"
+            @keydown="onCellKeydown(bar)"
+        >
+            <!-- bar rendering here -->
+        </g>
+    </g>
+</GanttChartPrimitive>
+```
+
+- `onGridKeydown` handles Home/End/PageUp/PageDown navigation across the grid.
+- `onCellKeydown` manages Enter, Space, and arrow key movement between bars.
 
 ## Task
 - Develop a comprehensive accessibility guide referencing `COMPOSABLE_GANTT.md` and WAI-ARIA resources, covering all keyboard interactions and ARIA roles.


### PR DESCRIPTION
## Summary
- expand step2 accessibility keyboard doc
- show example markup for grid navigation

## Testing
- `pnpm --dir frontend lint`
- `pnpm --dir frontend typecheck` *(fails: Cannot find name 'ImportMetaEnv', etc.)*
- `mage lint` *(failed: signal interrupt)*
- `mage test:unit` *(failed: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68534c691db08320a3e65e0556b35cb2