### PR TITLE
docs: clarify config merging

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -528,6 +528,10 @@ func setConfigFromEnv() error {
 	return viper.MergeConfigMap(configMap)
 }
 
+// mergeConfigFromPath loads a config file from the given directory and merges
+// it into the main viper instance. Viper itself only reads the first config
+// file found when multiple paths are configured, so we manually merge any
+// additional configs found in subsequent paths.
 func mergeConfigFromPath(p string) {
 	if p == "" {
 		return


### PR DESCRIPTION
## Summary
- clarify why `mergeConfigFromPath` is needed

## Testing
- `mage lint:fix` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68509889796c8320a181e848271052c9