### PR TITLE
Add deliverable checklists to Gantt docs

### DIFF
--- a/gantt_docs/phase1_landscape_style_research.md
+++ b/gantt_docs/phase1_landscape_style_research.md
@@ -40,5 +40,10 @@ rendering and behavior.
 
 ## Task
 - Expand this document with deeper research from `COMPOSABLE_GANTT.md` and other sources, detailing specific takeaways and references for each bullet point.
+- [ ] Document findings from Headless UI
+- [ ] Summarize VueUse guidelines
+- [ ] Outline Reka UI class passthrough patterns
+- [ ] Describe vue-ganttastic slot usage
+- [ ] Provide references to each source
 
 Back to [index](index.md)

--- a/gantt_docs/phase2_api_architecture_design.md
+++ b/gantt_docs/phase2_api_architecture_design.md
@@ -9,5 +9,9 @@ In this phase the project defines the core composables and renderless components
 
 ## Task
 - Produce a more detailed design document using `COMPOSABLE_GANTT.md` as the primary reference, expanding on component APIs and architectural diagrams.
+- [ ] Outline core composable functions and renderless components
+- [ ] Document props, slots, and emitted events
+- [ ] Include architecture diagrams for data flow and interactions
+- [ ] Provide TypeScript definition examples
 
 Back to [index](index.md)

--- a/gantt_docs/phase3_implementation_infrastructure.md
+++ b/gantt_docs/phase3_implementation_infrastructure.md
@@ -9,5 +9,9 @@
 
 ## Task
 - Expand on build tools, directory conventions, and accessibility patterns using `COMPOSABLE_GANTT.md` and additional references.
+- [ ] Detail Vite, TypeScript, and testing tool configuration
+- [ ] Provide a sample directory layout
+- [ ] Describe ARIA roles and keyboard navigation patterns
+- [ ] Include example configuration snippets
 
 Back to [index](index.md)

--- a/gantt_docs/phase4_testing_quality.md
+++ b/gantt_docs/phase4_testing_quality.md
@@ -56,5 +56,9 @@ test('bars can be dragged', async ({ page }) => {
 
 ## Task
 - Build out a complete testing strategy referencing `COMPOSABLE_GANTT.md` and other resources on Vue testing best practices.
+- [ ] Define unit and end-to-end test requirements
+- [ ] Document linting and formatting checks
+- [ ] Outline GitHub Actions workflow steps
+- [ ] Include tips for mocking and headless browser usage
 
 Back to [index](index.md)

--- a/gantt_docs/phase5_documentation_distribution.md
+++ b/gantt_docs/phase5_documentation_distribution.md
@@ -60,5 +60,9 @@ export default defineConfig({
 
 ## Task
 - Elaborate on distribution workflow and documentation site structure using information from `COMPOSABLE_GANTT.md` and related resources.
+- [ ] Outline VitePress documentation sections
+- [ ] Summarize npm release steps and versioning
+- [ ] Provide CHANGELOG and migration guide templates
+- [ ] Reference Storybook and example demos
 
 Back to [index](index.md)

--- a/gantt_docs/step1_project_setup.md
+++ b/gantt_docs/step1_project_setup.md
@@ -8,3 +8,7 @@ From the implementation concept derived from `COMPOSABLE_GANTT.md`:
 
 ## Task
 - Extend this setup guide with concrete initialization commands and folder layouts, citing `COMPOSABLE_GANTT.md` along with other setup best practices.
+- [ ] List commands to bootstrap the project
+- [ ] Show recommended folder structure
+- [ ] Reference configuration from `COMPOSABLE_GANTT.md`
+- [ ] Mention styling guidelines for integrators

--- a/gantt_docs/step2_accessibility_keyboard_support.md
+++ b/gantt_docs/step2_accessibility_keyboard_support.md
@@ -8,3 +8,7 @@ Based on the concept and `COMPOSABLE_GANTT.md`:
 
 ## Task
 - Develop a comprehensive accessibility guide referencing `COMPOSABLE_GANTT.md` and WAI-ARIA resources, covering all keyboard interactions and ARIA roles.
+- [ ] Document required ARIA roles and attributes
+- [ ] Describe keyboard navigation patterns
+- [ ] Provide example code snippets
+- [ ] Link to relevant WAI-ARIA documentation

--- a/gantt_docs/step3_customization_extensibility.md
+++ b/gantt_docs/step3_customization_extensibility.md
@@ -8,3 +8,7 @@ This step ensures that users can extend the library. Notes from `COMPOSABLE_GANT
 
 ## Task
 - Write an extended customization guide referencing `COMPOSABLE_GANTT.md` and other libraries that support composable customization.
+- [ ] Explain available configuration options
+- [ ] Include Tailwind wrapper examples
+- [ ] Show how to extend primitives with custom behavior
+- [ ] Link to inspiration from other libraries

--- a/gantt_docs/step4_documentation_examples.md
+++ b/gantt_docs/step4_documentation_examples.md
@@ -8,3 +8,7 @@ As suggested by the concept and `COMPOSABLE_GANTT.md`:
 
 ## Task
 - Create an expanded documentation plan referencing `COMPOSABLE_GANTT.md` and existing Storybook/VitePress setups.
+- [ ] Outline Storybook stories to include
+- [ ] Draft VitePress documentation pages
+- [ ] Provide example integrations for common use cases
+- [ ] Link design rationale from the concept document

--- a/gantt_docs/step5_testing_ci.md
+++ b/gantt_docs/step5_testing_ci.md
@@ -8,3 +8,7 @@ Implementation also calls for automated checks:
 
 ## Task
 - Provide a full CI configuration outline using `COMPOSABLE_GANTT.md` as a starting point and referencing common GitHub Actions patterns.
+- [ ] List lint, test, and build job steps
+- [ ] Include example workflow YAML
+- [ ] Mention test coverage reporting
+- [ ] Show how to add status badges


### PR DESCRIPTION
## Summary
- document deliverable checklists for every task in `gantt_docs`

## Testing
- `mage test:unit` *(fails: pattern dist not found)*
- `mage test:integration` *(fails due to interrupt)*
- `pnpm --dir frontend lint`
- `pnpm --dir frontend typecheck` *(fails with several errors)*
- `pnpm --dir frontend test:unit` *(fails with exit code 130)*

------
https://chatgpt.com/codex/tasks/task_e_68534ce1a4dc832092cd04690553ed81