### PR TITLE
Add layered architecture code examples

### DIFF
--- a/gantt_docs/index.md
+++ b/gantt_docs/index.md
@@ -15,3 +15,4 @@ This directory hosts summary documents for each project phase and implementation
 - [Step 3: Customization & Extensibility](step3_customization_extensibility.md)
 - [Step 4: Documentation & Examples](step4_documentation_examples.md)
 - [Step 5: Testing & CI](step5_testing_ci.md)
+- [Layered Architecture Code Examples](layer_code_examples.md)

--- a/gantt_docs/layer_code_examples.md
+++ b/gantt_docs/layer_code_examples.md
@@ -1,0 +1,76 @@
+# Layered Architecture Code Examples
+
+This document demonstrates minimal Vue snippets for the three-layer architecture described in [COMPOSABLE_GANTT.md](../composable-gantt/COMPOSABLE_GANTT.md).
+
+## Core Layer – `GanttBarPrimitive.vue`
+
+```vue
+<script setup lang="ts">
+const props = defineProps({
+  id: String,
+  modelValue: Object,
+  as: { type: String, default: 'rect' }
+})
+const { dragging, selected, onDragStart, onKeyDown } = useGanttBar(props)
+</script>
+
+<component
+  :is="as"
+  :data-state="[dragging && 'dragging', selected && 'selected'].filter(Boolean).join(' ')"
+  role="slider"
+  tabindex="0"
+  @mousedown="onDragStart"
+  @keydown="onKeyDown"
+>
+  <slot :dragging="dragging" :selected="selected" />
+</component>
+```
+
+## Styled Layer – `StyledGanttBar.vue`
+
+```vue
+<script setup lang="ts">
+import GanttBarPrimitive from './GanttBarPrimitive.vue'
+
+defineProps<{ model: any }>()
+</script>
+
+<GanttBarPrimitive :model-value="model" as="rect" v-slot="{ dragging, selected }">
+  <rect
+    :x="model.start"
+    :width="model.end - model.start"
+    y="4"
+    height="16"
+    rx="3"
+    :class="[
+      'fill-blue-500',
+      dragging && 'opacity-50',
+      selected && 'stroke-blue-700'
+    ]"
+  />
+</GanttBarPrimitive>
+```
+
+## Domain Layer – `TaskGanttChart.vue`
+
+```vue
+<script setup lang="ts">
+import StyledGanttBar from './StyledGanttBar.vue'
+import useGantt from './useGantt'
+
+const { rows, bars } = useGantt({ start: new Date(), end: new Date() })
+</script>
+
+<svg>
+  <g v-for="row in rows" :key="row.id">
+    <StyledGanttBar
+      v-for="bar in bars[row.id]"
+      :key="bar.id"
+      :model="bar"
+    />
+  </g>
+</svg>
+```
+
+Back to [index](index.md).
+


### PR DESCRIPTION
## Summary
- add minimal code snippets demonstrating core, styled and domain layers
- link the new examples from the gantt docs index

## Testing
- `mage lint`

------
https://chatgpt.com/codex/tasks/task_e_68534cb5c7e48320843476650a65c9bb