### PR TITLE
Add deliverable checklists to Gantt docs

### DIFF
--- a/gantt_docs/phase1_landscape_style_research.md
+++ b/gantt_docs/phase1_landscape_style_research.md
@@ -40,5 +40,8 @@ rendering and behavior.
 
 ## Task
 - Expand this document with deeper research from `COMPOSABLE_GANTT.md` and other sources, detailing specific takeaways and references for each bullet point.
+- [ ] Research summary covering headless libraries
+- [ ] Styling comparison notes
+- [ ] Reference links for further reading
 
 Back to [index](index.md)

--- a/gantt_docs/phase2_api_architecture_design.md
+++ b/gantt_docs/phase2_api_architecture_design.md
@@ -9,5 +9,8 @@ In this phase the project defines the core composables and renderless components
 
 ## Task
 - Produce a more detailed design document using `COMPOSABLE_GANTT.md` as the primary reference, expanding on component APIs and architectural diagrams.
+- [ ] API specification with props and events
+- [ ] Component and slot diagrams
+- [ ] Typed interface definitions
 
 Back to [index](index.md)

--- a/gantt_docs/phase3_implementation_infrastructure.md
+++ b/gantt_docs/phase3_implementation_infrastructure.md
@@ -9,5 +9,8 @@
 
 ## Task
 - Expand on build tools, directory conventions, and accessibility patterns using `COMPOSABLE_GANTT.md` and additional references.
+- [ ] Build tool configuration overview
+- [ ] Recommended directory layout
+- [ ] Accessibility checklist for primitives
 
 Back to [index](index.md)

--- a/gantt_docs/phase4_testing_quality.md
+++ b/gantt_docs/phase4_testing_quality.md
@@ -56,5 +56,8 @@ test('bars can be dragged', async ({ page }) => {
 
 ## Task
 - Build out a complete testing strategy referencing `COMPOSABLE_GANTT.md` and other resources on Vue testing best practices.
+- [ ] Vitest unit test examples
+- [ ] Playwright scenario samples
+- [ ] GitHub Actions workflow snippet
 
 Back to [index](index.md)

--- a/gantt_docs/phase5_documentation_distribution.md
+++ b/gantt_docs/phase5_documentation_distribution.md
@@ -60,5 +60,9 @@ export default defineConfig({
 
 ## Task
 - Elaborate on distribution workflow and documentation site structure using information from `COMPOSABLE_GANTT.md` and related resources.
+- [ ] VitePress navigation layout
+- [ ] Storybook example list
+- [ ] npm publishing steps
+- [ ] CHANGELOG and migration guide templates
 
 Back to [index](index.md)

--- a/gantt_docs/step1_project_setup.md
+++ b/gantt_docs/step1_project_setup.md
@@ -8,5 +8,8 @@ From the implementation concept derived from `COMPOSABLE_GANTT.md`:
 
 ## Task
 - Extend this setup guide with concrete initialization commands and folder layouts, citing `COMPOSABLE_GANTT.md` along with other setup best practices.
+- [ ] Vite initialization steps
+- [ ] Directory scaffold diagram
+- [ ] Minimal usage example
 
 Back to [index](index.md)

--- a/gantt_docs/step2_accessibility_keyboard_support.md
+++ b/gantt_docs/step2_accessibility_keyboard_support.md
@@ -8,5 +8,8 @@ Based on the concept and `COMPOSABLE_GANTT.md`:
 
 ## Task
 - Develop a comprehensive accessibility guide referencing `COMPOSABLE_GANTT.md` and WAI-ARIA resources, covering all keyboard interactions and ARIA roles.
+- [ ] ARIA role mapping table
+- [ ] Keyboard interaction matrix
+- [ ] Focus management examples
 
 Back to [index](index.md)

--- a/gantt_docs/step3_customization_extensibility.md
+++ b/gantt_docs/step3_customization_extensibility.md
@@ -8,5 +8,8 @@ This step ensures that users can extend the library. Notes from `COMPOSABLE_GANT
 
 ## Task
 - Write an extended customization guide referencing `COMPOSABLE_GANTT.md` and other libraries that support composable customization.
+- [ ] Configurable options reference
+- [ ] Tailwind wrapper example
+- [ ] Customization demo
 
 Back to [index](index.md)

--- a/gantt_docs/step4_documentation_examples.md
+++ b/gantt_docs/step4_documentation_examples.md
@@ -8,5 +8,8 @@ As suggested by the concept and `COMPOSABLE_GANTT.md`:
 
 ## Task
 - Create an expanded documentation plan referencing `COMPOSABLE_GANTT.md` and existing Storybook/VitePress setups.
+- [ ] Outline Storybook sections
+- [ ] Example docs pages
+- [ ] Integration demonstrations
 
 Back to [index](index.md)

--- a/gantt_docs/step5_testing_ci.md
+++ b/gantt_docs/step5_testing_ci.md
@@ -8,5 +8,8 @@ Implementation also calls for automated checks:
 
 ## Task
 - Provide a full CI configuration outline using `COMPOSABLE_GANTT.md` as a starting point and referencing common GitHub Actions patterns.
+- [ ] GitHub Actions workflow file
+- [ ] Test matrix definition
+- [ ] Lint and build commands
 
 Back to [index](index.md)


### PR DESCRIPTION
## Summary
- outline bullet-point deliverables for each task document in `gantt_docs/`

## Testing
- `pnpm --dir frontend lint`
- `pnpm --dir frontend typecheck` *(fails: type errors in unrelated files)*
- `mage lint`

------
https://chatgpt.com/codex/tasks/task_e_6853a59508b4832082ef028b16ff149d