### PR TITLE
Add test coverage target

### DIFF
--- a/gantt_docs/phase4_testing_quality.md
+++ b/gantt_docs/phase4_testing_quality.md
@@ -6,6 +6,7 @@ Testing and quality assurance goals from `COMPOSABLE_GANTT.md`:
 - End-to-end tests for interactive behavior using Playwright.
 - Apply ESLint, Prettier, and TypeScript rules following the Vue style guide.
 - Configure GitHub Actions for build, test, and publishing workflows.
+- Target at least **80% unit-test coverage** using Vitest's coverage reports.
 
 ## Example configuration
 


### PR DESCRIPTION
## Summary
- mention a new coverage goal in phase4 docs

## Testing
- `pnpm --dir frontend exec vitest run`
- `pnpm --dir frontend lint`
- `pnpm --dir frontend typecheck` *(fails: src/views/user/settings files have type errors)*
- `mage test:unit` *(fails: could not download modules)*
- `mage test:integration` *(fails: could not download modules)*

------
https://chatgpt.com/codex/tasks/task_e_68534ca4eb408320aaeeb61100b1e8f0