### PR TITLE
Add three-layer gantt diagram

### DIFF
--- a/gantt_docs/three_layer_architecture.svg
+++ b/gantt_docs/three_layer_architecture.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="200" viewBox="0 0 300 200">
+  <style>
+    .box { fill: #f3f4f6; stroke: #111827; stroke-width: 2; }
+    .label { font-family: sans-serif; font-size: 14px; fill: #111827; text-anchor: middle; }
+    .arrow { fill: none; stroke: #111827; stroke-width: 2; marker-end: url(#arrowhead); }
+  </style>
+  <defs>
+    <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="0" refY="3.5" orient="auto">
+      <polygon points="0 0, 10 3.5, 0 7" fill="#111827" />
+    </marker>
+  </defs>
+  <rect x="50" y="130" width="200" height="40" class="box" />
+  <text x="150" y="155" class="label">Primitives</text>
+
+  <rect x="50" y="70" width="200" height="40" class="box" />
+  <text x="150" y="95" class="label">Styled Wrappers</text>
+
+  <rect x="50" y="10" width="200" height="40" class="box" />
+  <text x="150" y="35" class="label">Domain Components</text>
+
+  <path d="M150 130 L150 110" class="arrow" />
+  <path d="M150 70 L150 50" class="arrow" />
+</svg>


### PR DESCRIPTION
## Summary
- add a simple SVG showing primitives, styled wrappers and domain components

## Testing
- `pnpm --dir frontend install --frozen-lockfile`
- `pnpm --dir frontend lint`
- `mage lint`


------
https://chatgpt.com/codex/tasks/task_e_68534c658efc832098a1deedf223b58d