### PR TITLE
Add cypress test for duplicate notifications

### DIFF
--- a/frontend/cypress/e2e/misc/notifications.spec.ts
+++ b/frontend/cypress/e2e/misc/notifications.spec.ts
@@ -1,0 +1,24 @@
+import {createFakeUserAndLogin} from '../../support/authenticateUser'
+
+describe('Duplicate Notifications', () => {
+        createFakeUserAndLogin()
+
+        it('Merges duplicate notifications and shows count', () => {
+                cy.visit('/')
+
+                cy.window().then(win => {
+                        const app = win.document.getElementById('app') as any
+                        // Access the vue app instance to trigger notifications
+                        const vueApp = (app as any).__vue_app__
+                        vueApp.config.globalProperties.$message.success({message: 'Duplicate Test'})
+                        vueApp.config.globalProperties.$message.success({message: 'Duplicate Test'})
+                })
+
+                cy.get('.global-notification .vue-notification.success')
+                        .should('have.length', 1)
+                        .find('.notification-content')
+                        .should('contain', 'Duplicate Test')
+                        .find('span')
+                        .should('contain', '×2')
+        })
+})


### PR DESCRIPTION
## Summary
- add e2e test to verify duplicate notifications are merged

## Testing
- `pnpm lint:fix`
- `pnpm test:e2e` *(fails: dist directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_6853aa3b0e64832096ff4be5874a4189