### PR TITLE
Fix provider info and timezone types

### DIFF
--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -50,8 +50,8 @@ function redirectToSpecifiedProvider() {
 	}
 }
 
-function getLoggedInVia(): string | null {
-	return localStorage.getItem('loggedInViaProvider')
+export function getLoggedInVia(): string | null {
+        return localStorage.getItem('loggedInViaProvider')
 }
 
 function setLoggedInVia(provider: string | null): void {
@@ -75,7 +75,9 @@ export const useAuthStore = defineStore('auth', () => {
 	
 	const lastUserInfoRefresh = ref<Date | null>(null)
 	const isLoading = ref(false)
-	const isLoadingGeneralSettings = ref(false)
+       const isLoadingGeneralSettings = ref(false)
+
+       const loggedInVia = computed(() => getLoggedInVia())
 
 	const authUser = computed(() => {
 		return authenticated.value && (
@@ -453,7 +455,8 @@ export const useAuthStore = defineStore('auth', () => {
 
 		authUser,
 		authLinkShare,
-		userDisplayName,
+               userDisplayName,
+               loggedInVia,
 
 		isLoading: readonly(isLoading),
 		setIsLoading,


### PR DESCRIPTION
## Summary
- expose `getLoggedInVia` from auth store and use new computed property for UI
- fix timezone helper types and callback
- handle undefined project IDs in user settings and pass `showMessage` to `saveUserSettings`

## Testing
- `pnpm --dir frontend lint`
- `pnpm --dir frontend typecheck` *(fails: Avatar.vue, Caldav.vue, ApiTokens.vue, Deletion.vue, TOTP.vue)*

------
https://chatgpt.com/codex/tasks/task_e_6853ba38759c8320a4827932adc43880