### PR TITLE
Fix TipTap model binding and add tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS
+
+These instructions summarize the development guidelines from the official Vikunja docs and CI workflows. They apply to the entire repository.
+
+## Development Environment
+- Use [devenv](https://devenv.sh/) to get a shell with all required tools.
+
+## Building From Source
+1. Clone the repo and check out the desired version.
+2. **Frontend**:
+   - Requires Node.js 20+ and pnpm.
+   - Run `pnpm install` inside `frontend/`.
+   - Build with `pnpm run build` to create the `dist/` bundle.
+   - Lint with `pnpm lint` and run TypeScript checks with `pnpm typecheck`.
+   - Run frontend unit tests with `pnpm test:unit`.
+3. **API**:
+   - Requires Go 1.21+ and Mage.
+   - If the frontend bundle is missing, create one or a dummy file with `mkdir -p frontend/dist && touch frontend/dist/index.html`.
+   - Build with `mage build`.
+   - Lint with `mage lint` and run `mage check:translations` when translation files change.
+4. Cross‑compile with `mage release` or `mage release:{linux|windows|darwin}`.
+
+## Testing
+- Set `VIKUNJA_SERVICE_ROOTPATH` to the repository root before running tests so fixtures load correctly.
+- Run API unit tests with `mage test:unit`.
+- Run API integration tests with `mage test:integration`.
+- Run frontend unit tests with `pnpm test:unit`.
+
+## Pull Requests
+- PRs must be opened on our [Gitea instance](https://kolaente.dev/vikunja) against the `main` branch.
+- Keep PRs small and focused. Allow maintainers to edit your branch.
+- Describe the problem in the PR title and provide a summary in the first comment.
+- If the PR changes the UI, include after screenshots.
+- Reference issues with `Fixes/Closes/Resolves #<number>` each on its own line.
+- Conventional Commit messages are appreciated but not mandatory.

--- a/frontend/src/components/input/editor/TipTap.test.ts
+++ b/frontend/src/components/input/editor/TipTap.test.ts
@@ -1,0 +1,115 @@
+import {mount} from '@vue/test-utils'
+import {nextTick, ref} from 'vue'
+import {describe, it, expect, vi, beforeEach} from 'vitest'
+
+// Stub i18n composable used in the component
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({t: (s: string) => s}),
+}))
+
+// Stub the project i18n utilities
+vi.mock('@/i18n', () => ({
+  i18n: {},
+  getBrowserLanguage: () => 'en',
+}))
+
+// Stub EditorToolbar to avoid relying on editor methods
+vi.mock('@/components/input/editor/EditorToolbar.vue', () => ({
+  default: {template: '<div></div>'},
+}))
+
+import TipTap from './TipTap.vue'
+
+// Mock @tiptap/vue-3 components and composables
+let editor: any
+let onUpdate: () => void
+const setContentMock = vi.fn()
+
+vi.mock('@tiptap/vue-3', () => {
+  return {
+    EditorContent: {
+      template: '<div></div>',
+    },
+    BubbleMenu: {
+      template: '<div><slot /></div>',
+    },
+    useEditor: (options: any) => {
+      onUpdate = options.onUpdate
+      editor = {
+        getHTML: vi.fn(() => '<p>new</p>'),
+        commands: {
+          setContent: setContentMock,
+          focus: vi.fn(() => ({run: vi.fn()})),
+        },
+        isActive: vi.fn(() => false),
+        setEditable: vi.fn(),
+      }
+      return ref(editor)
+    },
+  }
+})
+
+describe('TipTap.vue', () => {
+  beforeEach(() => {
+    setContentMock.mockClear()
+    if (editor) {
+      editor.getHTML.mockClear()
+      editor.setEditable.mockClear()
+    }
+  })
+
+  const globalMountOptions = {
+    global: {
+      stubs: ['Icon', 'RouterLink'],
+      directives: {tooltip: () => {}, cy: () => {}},
+      config: {
+        globalProperties: {
+          $t: (s: string) => s,
+        },
+      },
+    },
+  }
+
+  it('initializes editor with modelValue', async () => {
+    mount(TipTap, {props: {modelValue: '<p>hello</p>'}, ...globalMountOptions})
+    await nextTick()
+    expect(setContentMock).toHaveBeenCalledWith('<p>hello</p>', false)
+  })
+
+  it('emits update on editor change', async () => {
+    const wrapper = mount(TipTap, {props: {modelValue: '<p>hello</p>'}, ...globalMountOptions})
+    await nextTick()
+    onUpdate()
+    expect(wrapper.emitted()['update:modelValue'][0]).toEqual(['<p>new</p>'])
+  })
+
+  it('updates editor when modelValue prop changes', async () => {
+    const wrapper = mount(TipTap, {props: {modelValue: '<p>a</p>'}, ...globalMountOptions})
+    await nextTick()
+    setContentMock.mockClear()
+    await wrapper.setProps({modelValue: '<p>b</p>'})
+    await nextTick()
+    expect(setContentMock).toHaveBeenCalledWith('<p>b</p>', false)
+  })
+
+  it('shows edit button when value is not empty', async () => {
+    const wrapper = mount(TipTap, {props: {modelValue: '<p>a</p>'}, ...globalMountOptions})
+    await nextTick()
+    expect(wrapper.find('.done-edit').exists()).toBe(true)
+  })
+
+  it('hides edit button when value is empty', async () => {
+    const wrapper = mount(TipTap, {props: {modelValue: ''}, ...globalMountOptions})
+    await nextTick()
+    expect(wrapper.find('.done-edit').exists()).toBe(false)
+  })
+
+  it('enters edit mode when clicking the edit button', async () => {
+    const wrapper = mount(TipTap, {props: {modelValue: '<p>a</p>'}, ...globalMountOptions})
+    await nextTick()
+    await wrapper.find('.done-edit').trigger('click')
+    await nextTick()
+    expect(editor.setEditable).toHaveBeenCalledWith(true)
+    expect(wrapper.find('.done-edit').exists()).toBe(false)
+  })
+})

--- a/frontend/src/components/input/editor/TipTap.vue
+++ b/frontend/src/components/input/editor/TipTap.vue
@@ -137,7 +137,7 @@
 </template>
 
 <script setup lang="ts">
-import {computed, nextTick, onBeforeUnmount, onMounted, ref, watch} from 'vue'
+import {computed, nextTick, onBeforeUnmount, onMounted, ref, watch, watchEffect} from 'vue'
 import {useI18n} from 'vue-i18n'
 import {eventToHotkeyString} from '@github/hotkey'
 
@@ -164,8 +164,6 @@ import TaskItem from '@tiptap/extension-task-item'
 import TaskList from '@tiptap/extension-task-list'
 import HardBreak from '@tiptap/extension-hard-break'
 
-import {Node} from '@tiptap/pm/model'
-
 import Commands from './commands'
 import suggestionSetup from './suggestion'
 
@@ -184,7 +182,6 @@ import inputPrompt from '@/helpers/inputPrompt'
 import {setLinkInEditor} from '@/components/input/editor/setLinkInEditor'
 
 const props = withDefaults(defineProps<{
-	modelValue: string,
 	uploadCallback?: UploadCallback,
 	isEditEnabled?: boolean,
 	bottomActions?: BottomAction[],
@@ -202,7 +199,9 @@ const props = withDefaults(defineProps<{
 	enableDiscardShortcut: false,
 })
 
-const emit = defineEmits(['update:modelValue', 'save'])
+const emit = defineEmits(['save', 'update:modelValue'])
+
+const modelValue = defineModel<string>({ default: '' })
 
 const tiptapInstanceRef = ref<HTMLInputElement | null>(null)
 
@@ -267,7 +266,7 @@ const CustomImage = Image.extend({
 
 			nextTick(async () => {
 
-				const img = document.getElementById(id)
+				const img = document.getElementById(id) as HTMLImageElement | null
 
 				if (!img) return
 
@@ -308,7 +307,7 @@ const UPLOAD_PLACEHOLDER_ELEMENT = '<p>UPLOAD_PLACEHOLDER</p>'
 let lastSavedState = ''
 
 watch(
-	() => props.modelValue,
+	modelValue,
 	(newValue) => {
 		if (!contentHasChanged.value) {
 			lastSavedState = newValue
@@ -318,7 +317,7 @@ watch(
 )
 
 watch(
-	() => internalMode.value,
+	internalMode,
 	mode => {
 		if (mode === 'preview') {
 			contentHasChanged.value = false
@@ -344,10 +343,9 @@ const PasteHandler = Extension.create({
 					handlePaste: (view, event) => {
 						
 						// Handle images pasted from clipboard
-						if (typeof props.uploadCallback !== 'undefined' && event.clipboardData?.items?.length > 0) {
+						if (typeof props.uploadCallback !== 'undefined' && event.clipboardData?.items?.length) {
 
 							for (const item of event.clipboardData.items) {
-								console.log({item})
 								if (item.kind === 'file' && item.type.startsWith('image/')) {
 									const file = item.getAsFile()
 									if (file) {
@@ -401,25 +399,19 @@ const extensions : Extensions = [
 	}),
 
 	Placeholder.configure({
-		placeholder: ({editor}) => {
-			if (!isEditing.value) {
+		placeholder({editor}) {
+			if (!isEditing.value || editor.getText() !== '' && !editor.isFocused) {
 				return ''
 			}
 
-			if (editor.getText() !== '' && !editor.isFocused) {
-				return ''
-			}
-
-			return props.placeholder !== ''
-				? props.placeholder
-				: t('input.editor.placeholder')
+			return props.placeholder || t('input.editor.placeholder')
 		},
 	}),
 	Typography,
 	Underline,
 	Link.configure({
 		openOnClick: false,
-		validate: (href: string) => (new RegExp(
+		validate: (href) => (new RegExp(
 			`^(https?|${additionalLinkProtocols.join('|')}):\\/\\/`,
 			'i',
 		)).test(href),
@@ -438,7 +430,7 @@ const extensions : Extensions = [
 	TaskList,
 	TaskItem.configure({
 		nested: true,
-		onReadOnlyChecked: (node: Node, checked: boolean): boolean => {
+		onReadOnlyChecked(node, checked) {
 			if (!props.isEditEnabled) {
 				return false
 			}
@@ -491,21 +483,13 @@ const editor = useEditor({
 	// eslint-disable-next-line vue/no-ref-object-reactivity-loss
 	editable: isEditing.value,
 	extensions: extensions,
-	onUpdate: () => {
-		bubbleNow()
-	},
+	onUpdate: bubbleNow,
 })
 
-watch(
-	() => isEditing.value,
-	() => {
-		editor.value?.setEditable(isEditing.value)
-	},
-	{immediate: true},
-)
+watchEffect(() => editor.value?.setEditable(isEditing.value))
 
 watch(
-	() => props.modelValue,
+	modelValue,
 	value => {
 		if (!editor?.value) return
 
@@ -519,13 +503,14 @@ watch(
 )
 
 function bubbleNow() {
-	if (editor.value?.getHTML() === props.modelValue ||
-		(editor.value?.getHTML() === '<p></p>') && props.modelValue === '') {
-		return
-	}
+       const editorVal = editor.value!.getHTML()
+       if (editorVal === modelValue.value ||
+               (editorVal === '<p></p>') && modelValue.value === '') {
+               return
+       }
 
-	contentHasChanged.value = true
-	emit('update:modelValue', editor.value?.getHTML())
+       contentHasChanged.value = true
+       emit('update:modelValue', editorVal)
 }
 
 function bubbleSave() {
@@ -633,7 +618,7 @@ onMounted(async () => {
 
 	await nextTick()
 
-	setModeAndValue(props.modelValue)
+        setModeAndValue(modelValue.value)
 })
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
## Summary
- update `bubbleNow` to emit model changes instead of mutating the ref
- cover TipTap preview/edit logic in tests and stub EditorToolbar

## Testing
- `pnpm lint`
- `pnpm test:unit --run --reporter dot`
- `pnpm typecheck` *(fails: see logs)*

------
https://chatgpt.com/codex/tasks/task_e_684295f5ce04832090a0e7b3b6664308