### PR TITLE
support seconds as rate limit period fallback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS
+
+These instructions summarize the development guidelines from the official Vikunja docs and CI workflows. They apply to the entire repository.
+
+## Development Environment
+- Use [devenv](https://devenv.sh/) to get a shell with all required tools.
+
+## Building From Source
+1. Clone the repo and check out the desired version.
+2. **Frontend**:
+   - Requires Node.js 20+ and pnpm.
+   - Run `pnpm install` inside `frontend/`.
+   - Build with `pnpm run build` to create the `dist/` bundle.
+   - Lint with `pnpm lint` and run TypeScript checks with `pnpm typecheck`.
+   - Run frontend unit tests with `pnpm test:unit`.
+3. **API**:
+   - Requires Go 1.21+ and Mage.
+   - If the frontend bundle is missing, create one or a dummy file with `mkdir -p frontend/dist && touch frontend/dist/index.html`.
+   - Build with `mage build`.
+   - Lint with `mage lint` and run `mage check:translations` when translation files change.
+4. Cross‑compile with `mage release` or `mage release:{linux|windows|darwin}`.
+
+## Testing
+- Set `VIKUNJA_SERVICE_ROOTPATH` to the repository root before running tests so fixtures load correctly.
+- Run API unit tests with `mage test:unit`.
+- Run API integration tests with `mage test:integration`.
+- Run frontend unit tests with `pnpm test:unit`.
+
+## Pull Requests
+- PRs must be opened on our [Gitea instance](https://kolaente.dev/vikunja) against the `main` branch.
+- Keep PRs small and focused. Allow maintainers to edit your branch.
+- Describe the problem in the PR title and provide a summary in the first comment.
+- If the PR changes the UI, include after screenshots.
+- Reference issues with `Fixes/Closes/Resolves #<number>` each on its own line.
+- Conventional Commit messages are appreciated but not mandatory.

--- a/config-raw.json
+++ b/config-raw.json
@@ -449,8 +449,8 @@
                 },
                 {
                     "key": "period",
-                    "default_value": "60",
-                    "comment": "The time period in seconds for the limit"
+                    "default_value": "1m",
+                    "comment": "The time period for the limit. Use any valid Go duration string"
                 },
                 {
                     "key": "limit",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -414,7 +414,7 @@ func InitDefaultConfig() {
 	RateLimitEnabled.setDefault(false)
 	RateLimitKind.setDefault("user")
 	RateLimitLimit.setDefault(100)
-	RateLimitPeriod.setDefault(60)
+	RateLimitPeriod.setDefault("60s")
 	RateLimitStore.setDefault("memory")
 	RateLimitNoAuthRoutesLimit.setDefault(10)
 	// Files

--- a/pkg/routes/rate_limit_test.go
+++ b/pkg/routes/rate_limit_test.go
@@ -1,0 +1,23 @@
+package routes
+
+import (
+	"testing"
+	"time"
+
+	"code.vikunja.io/api/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRateLimitDurationOneMinute(t *testing.T) {
+	config.InitDefaultConfig()
+	config.RateLimitPeriod.Set("1m")
+
+	assert.Equal(t, time.Minute, getRateLimitPeriod())
+}
+
+func TestRateLimitDurationSecondsFallback(t *testing.T) {
+	config.InitDefaultConfig()
+	config.RateLimitPeriod.Set(60)
+
+	assert.Equal(t, time.Minute, getRateLimitPeriod())
+}


### PR DESCRIPTION
## Summary
- add helper `getRateLimitPeriod` to handle numeric config values as seconds
- adjust `setupRateLimit` to use the helper
- test fallback behavior for legacy `60` configuration
- collapse numeric cases in `getRateLimitPeriod`

## Testing
- `go test ./pkg/routes -run RateLimitDuration -v`


------
https://chatgpt.com/codex/tasks/task_e_68429cf693688320aa0c44414611ed73