### PR TITLE
Fix OIDC issuer mismatch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS
+
+These instructions summarize the development guidelines from the official Vikunja docs and CI workflows. They apply to the entire repository.
+
+## Development Environment
+- Use [devenv](https://devenv.sh/) to get a shell with all required tools.
+
+## Building From Source
+1. Clone the repo and check out the desired version.
+2. **Frontend**:
+   - Requires Node.js 20+ and pnpm.
+   - Run `pnpm install` inside `frontend/`.
+   - Build with `pnpm run build` to create the `dist/` bundle.
+   - Lint with `pnpm lint` and run TypeScript checks with `pnpm typecheck`.
+   - Run frontend unit tests with `pnpm test:unit`.
+3. **API**:
+   - Requires Go 1.21+ and Mage.
+   - If the frontend bundle is missing, create one or a dummy file with `mkdir -p frontend/dist && touch frontend/dist/index.html`.
+   - Build with `mage build`.
+   - Lint with `mage lint` and run `mage check:translations` when translation files change.
+4. Cross‑compile with `mage release` or `mage release:{linux|windows|darwin}`.
+
+## Testing
+- Set `VIKUNJA_SERVICE_ROOTPATH` to the repository root before running tests so fixtures load correctly.
+- Run API unit tests with `mage test:unit`.
+- Run API integration tests with `mage test:integration`.
+- Run frontend unit tests with `pnpm test:unit`.
+
+## Pull Requests
+- PRs must be opened on our [Gitea instance](https://kolaente.dev/vikunja) against the `main` branch.
+- Keep PRs small and focused. Allow maintainers to edit your branch.
+- Describe the problem in the PR title and provide a summary in the first comment.
+- If the PR changes the UI, include after screenshots.
+- Reference issues with `Fixes/Closes/Resolves #<number>` each on its own line.
+- Conventional Commit messages are appreciated but not mandatory.

--- a/config-raw.json
+++ b/config-raw.json
@@ -681,6 +681,11 @@
                                             "comment": "The auth url to send users to if they want to authenticate using OpenID Connect."
                                         },
                                         {
+                                            "key": "issuerurl",
+                                            "default_value": "",
+                                            "comment": "Optional URL used as the expected issuer when it differs from `authurl`. Set this when your provider advertises a different external issuer in its discovery document."
+                                        },
+                                        {
                                             "key": "logouturl",
                                             "default_value": "",
                                             "comment": "The oidc logouturl that users will be redirected to on logout.\nLeave empty or delete key, if you do not want to be redirected."

--- a/pkg/modules/auth/openid/openid.go
+++ b/pkg/modules/auth/openid/openid.go
@@ -50,6 +50,7 @@ type Provider struct {
 	Name             string `json:"name"`
 	Key              string `json:"key"`
 	OriginalAuthURL  string `json:"-"`
+	IssuerURL        string `json:"issuer_url"`
 	AuthURL          string `json:"auth_url"`
 	LogoutURL        string `json:"logout_url"`
 	ClientID         string `json:"client_id"`
@@ -75,7 +76,11 @@ func init() {
 }
 
 func (p *Provider) setOicdProvider() (err error) {
-	p.openIDProvider, err = oidc.NewProvider(context.Background(), p.OriginalAuthURL)
+	url := p.OriginalAuthURL
+	if p.IssuerURL != "" {
+		url = p.IssuerURL
+	}
+	p.openIDProvider, err = oidc.NewProvider(context.Background(), url)
 	return err
 }
 

--- a/pkg/modules/auth/openid/providers.go
+++ b/pkg/modules/auth/openid/providers.go
@@ -121,6 +121,7 @@ func getProviderFromMap(pi map[string]interface{}, key string) (provider *Provid
 
 	allKeys := append(
 		[]string{
+			"issuerurl",
 			"logouturl",
 			"scope",
 			"emailfallback",
@@ -154,6 +155,14 @@ func getProviderFromMap(pi map[string]interface{}, key string) (provider *Provid
 		url, ok := logoutValue.(string)
 		if ok {
 			logoutURL = url
+		}
+	}
+
+	var issuerURL string
+	issuerValue, exists := pi["issuerurl"]
+	if exists {
+		if url, ok := issuerValue.(string); ok {
+			issuerURL = url
 		}
 	}
 
@@ -198,6 +207,7 @@ func getProviderFromMap(pi map[string]interface{}, key string) (provider *Provid
 		Key:              key,
 		AuthURL:          pi["authurl"].(string),
 		OriginalAuthURL:  pi["authurl"].(string),
+		IssuerURL:        issuerURL,
 		ClientSecret:     pi["clientsecret"].(string),
 		LogoutURL:        logoutURL,
 		Scope:            scope,


### PR DESCRIPTION
## Summary
- allow specifying an `issuer_url` for OpenID providers
- use the custom issuer URL when creating the provider
- document new option in config

## Testing
- `mage test:unit` *(failed: signal interrupt)*
- `mage test:integration` *(failed: signal interrupt)*
- `pnpm test:unit` *(failed: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684380f9a6d083208fe40851b4de7213