### PR TITLE
Use guard for disabled settings pages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AGENTS
+
+These instructions summarize the development guidelines from the official Vikunja docs and CI workflows. They apply to the entire repository.
+
+## Development Environment
+- Use [devenv](https://devenv.sh/) to get a shell with all required tools.
+
+## Building From Source
+1. Clone the repo and check out the desired version.
+2. **Frontend**:
+   - Requires Node.js 20+ and pnpm.
+   - Run `pnpm install` inside `frontend/`.
+   - Build with `pnpm run build` to create the `dist/` bundle.
+   - Lint with `pnpm lint` and run TypeScript checks with `pnpm typecheck`.
+   - Run frontend unit tests with `pnpm test:unit`.
+3. **API**:
+   - Requires Go 1.21+ and Mage.
+   - If the frontend bundle is missing, create one or a dummy file with `mkdir -p frontend/dist && touch frontend/dist/index.html`.
+   - Build with `mage build`.
+   - Lint with `mage lint` and run `mage check:translations` when translation files change.
+4. Cross‑compile with `mage release` or `mage release:{linux|windows|darwin}`.
+
+## Testing
+- Set `VIKUNJA_SERVICE_ROOTPATH` to the repository root before running tests so fixtures load correctly.
+- Run API unit tests with `mage test:unit`.
+- Run API integration tests with `mage test:integration`.
+- Run frontend unit tests with `pnpm test:unit`.
+
+## Pull Requests
+- PRs must be opened on our [Gitea instance](https://kolaente.dev/vikunja) against the `main` branch.
+- Keep PRs small and focused. Allow maintainers to edit your branch.
+- Describe the problem in the PR title and provide a summary in the first comment.
+- If the PR changes the UI, include after screenshots.
+- Reference issues with `Fixes/Closes/Resolves #<number>` each on its own line.
+- Conventional Commit messages are appreciated but not mandatory.

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -8,6 +8,7 @@ import {getNextWeekDate} from '@/helpers/time/getNextWeekDate'
 import {LINK_SHARE_HASH_PREFIX} from '@/constants/linkShareHash'
 
 import {useAuthStore} from '@/stores/auth'
+import {useConfigStore} from '@/stores/config'
 
 import Login from '@/views/user/Login.vue'
 import Register from '@/views/user/Register.vue'
@@ -432,6 +433,7 @@ export async function getAuthForRoute(to: RouteLocation, authStore) {
 
 router.beforeEach(async (to, from) => {
 	const authStore = useAuthStore()
+	const configStore = useConfigStore()
 
 	if(from.hash && from.hash.startsWith(LINK_SHARE_HASH_PREFIX)) {
 		to.hash = from.hash
@@ -453,6 +455,14 @@ router.beforeEach(async (to, from) => {
 			...newRoute,
 			hash: to.hash,
 		}
+	}
+
+	if (to.name === 'user.settings.caldav' && !configStore.caldavEnabled) {
+		return {name: 'user.settings.general', hash: to.hash}
+	}
+
+	if (to.name === 'user.settings.totp' && (!configStore.totpEnabled || !authStore.info?.isLocalUser)) {
+		return {name: 'user.settings.general', hash: to.hash}
 	}
 	
 	if(!to.fullPath.endsWith(to.hash)) {


### PR DESCRIPTION
## Summary
- add config store import
- check caldav and totp settings routes in navigation guard
- fix indentation for new guard logic

## Testing
- `pnpm lint`
- `pnpm build` *(fails: vite not found)*
- `pnpm typecheck` *(fails: vue-tsc not found)*
- `pnpm test:unit --run` *(fails: vitest not found)*
- `mage test:unit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68437eed443c83209f09731764a30fda