### PR TITLE
Improve iOS PWA support

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,9 +6,15 @@
 	<title>Vikunja</title>
 	<meta name="description" content="Vikunja (/vɪˈkuːnjə/) - The to-do app to organize your life.">
 	<meta name="theme-color" content="#1973ff"/>
+	<meta name="apple-mobile-web-app-capable" content="yes">
+	<meta name="apple-mobile-web-app-status-bar-style" content="default">
+	<meta name="apple-mobile-web-app-title" content="Vikunja">
+	<link rel="mask-icon" href="/images/icons/safari-pinned-tab.svg" color="#1973ff">
 
 	<link rel="icon" href="/favicon.ico">
 	<link rel="apple-touch-icon" href="/images/icons/apple-touch-icon-180x180.png"/>
+	<link rel="apple-touch-startup-image" href="/images/icons/android-chrome-512x512.png">
+	<!-- TODO: replace with dedicated startup images -->
 	<!--__vite-plugin-inject-preload__-->
 </head>
 <body>

--- a/frontend/src/styles/theme/theme.scss
+++ b/frontend/src/styles/theme/theme.scss
@@ -34,6 +34,7 @@ a, button {
 body {
   background: var(--site-background);
   min-height: 100vh;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
  
   @media print {
     background: #fff;


### PR DESCRIPTION
## Summary
- add iOS specific meta tags and Safari pinned tab icon
- apply safe-area padding on body
- add placeholder start-up image link

## Testing
- `pnpm lint`
- `pnpm typecheck` *(fails: Argument of type '{}' is not assignable)*
- `pnpm test:unit` *(exits watcher)*

------
https://chatgpt.com/codex/tasks/task_e_68482521b41c83209cb24cfbe9ec798e