### PR TITLE
Fix status code for CalDAV tokens handler

### DIFF
--- a/pkg/routes/api/v1/user_caldav_token.go
+++ b/pkg/routes/api/v1/user_caldav_token.go
@@ -77,7 +77,7 @@ func GetCaldavTokens(c echo.Context) error {
 		return handler.HandleHTTPError(err)
 	}
 
-	return c.JSON(http.StatusCreated, tokens)
+	return c.JSON(http.StatusOK, tokens)
 }
 
 // DeleteCaldavToken is the handler to delete a caldv token


### PR DESCRIPTION
## Summary
- return 200 OK from GetCaldavTokens instead of 201 Created

## Testing
- `mage lint`
- `VIKUNJA_SERVICE_ROOTPATH=$(pwd) mage test:unit` *(fails: Get "https://vikunja.io/testimage.jpg": Forbidden)*
- `VIKUNJA_SERVICE_ROOTPATH=$(pwd) mage test:integration`

------
https://chatgpt.com/codex/tasks/task_e_686683677144832084fc35af00d26267