### PR TITLE
Update email confirm test error handling

### DIFF
--- a/pkg/user/user_email_confirm_test.go
+++ b/pkg/user/user_email_confirm_test.go
@@ -67,8 +67,18 @@ func TestUserEmailConfirm(t *testing.T) {
 			s := db.NewSession()
 			defer s.Close()
 
-			if err := ConfirmEmail(s, tt.args.c); (err != nil) != tt.wantErr {
-				t.Errorf("ConfirmEmail() error = %v, wantErr %v", err, tt.wantErr)
+			err := ConfirmEmail(s, tt.args.c)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ConfirmEmail() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil {
+				if tt.errType != nil {
+					if !tt.errType(err) {
+						t.Fatalf("ConfirmEmail() unexpected error: %v", err)
+					}
+				} else {
+					t.Fatalf("ConfirmEmail() returned error: %v", err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- improve `TestUserEmailConfirm` assertions for returned errors

## Testing
- `go test ./pkg/user`

------
https://chatgpt.com/codex/tasks/task_e_686383c277fc8320b7ef0683d2853c50