### PR TITLE
Fix rate limiter duration handling

### DIFF
--- a/config-raw.json
+++ b/config-raw.json
@@ -452,8 +452,8 @@
                 },
                 {
                     "key": "period",
-                    "default_value": "60",
-                    "comment": "The time period in seconds for the limit"
+                    "default_value": "1m",
+                    "comment": "The time period for the limit as a duration string"
                 },
                 {
                     "key": "limit",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -414,7 +414,7 @@ func InitDefaultConfig() {
 	RateLimitEnabled.setDefault(false)
 	RateLimitKind.setDefault("user")
 	RateLimitLimit.setDefault(100)
-	RateLimitPeriod.setDefault(60)
+	RateLimitPeriod.setDefault("1m")
 	RateLimitStore.setDefault("memory")
 	RateLimitNoAuthRoutesLimit.setDefault(10)
 	// Files

--- a/pkg/routes/rate_limit.go
+++ b/pkg/routes/rate_limit.go
@@ -19,7 +19,6 @@ package routes
 import (
 	"net/http"
 	"strconv"
-	"time"
 
 	"code.vikunja.io/api/pkg/config"
 	"code.vikunja.io/api/pkg/log"
@@ -97,7 +96,7 @@ func createRateLimiter(rate limiter.Rate) *limiter.Limiter {
 func setupRateLimit(a *echo.Group, rateLimitKind string) {
 	if config.RateLimitEnabled.GetBool() {
 		rate := limiter.Rate{
-			Period: config.RateLimitPeriod.GetDuration() * time.Second,
+			Period: config.RateLimitPeriod.GetDuration(),
 			Limit:  config.RateLimitLimit.GetInt64(),
 		}
 		rateLimiter := createRateLimiter(rate)

--- a/pkg/routes/rate_limit_test.go
+++ b/pkg/routes/rate_limit_test.go
@@ -1,0 +1,42 @@
+// Vikunja is a to-do list application to facilitate your life.
+// Copyright 2018-present Vikunja and contributors. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package routes
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ulule/limiter/v3"
+
+	"code.vikunja.io/api/pkg/config"
+)
+
+func TestRateLimitPeriodDuration(t *testing.T) {
+	config.InitDefaultConfig()
+	config.RateLimitPeriod.Set("1m")
+	config.RateLimitStore.Set("memory")
+
+	rate := limiter.Rate{
+		Period: config.RateLimitPeriod.GetDuration(),
+		Limit:  config.RateLimitLimit.GetInt64(),
+	}
+
+	l := createRateLimiter(rate)
+	if l.Rate.Period != time.Minute {
+		t.Fatalf("expected period 1m, got %v", l.Rate.Period)
+	}
+}


### PR DESCRIPTION
## Summary
- update rate limiter to use configured duration directly
- adjust default rate limit period to `1m`
- document duration usage in config
- add a unit test for `1m` period

## Testing
- `mage lint:fix`
- `mage test:feature` *(fails: TestConvertTodoistToVikunja, TestConvertTrelloToVikunja)*

------
https://chatgpt.com/codex/tasks/task_e_6863addf48488320ac336207738956d3