### PR TITLE
Handle invalid account deletion token

### DIFF
--- a/frontend/src/i18n/lang/en.json
+++ b/frontend/src/i18n/lang/en.json
@@ -1178,6 +1178,7 @@
     "1023": "You can't do that as a link share.",
     "1024": "Invalid claim data for field {field} of type {type}.",
     "1025": "The timezone '{timezone}' is invalid. Please select a valid timezone from the list.",
+    "1027": "Invalid account deletion token.",
     "2001": "ID cannot be empty or 0.",
     "2002": "Some of the request data was invalid.",
     "2003": "The timezone '{timezone}' is invalid.",

--- a/pkg/user/delete.go
+++ b/pkg/user/delete.go
@@ -106,8 +106,7 @@ func ConfirmDeletion(s *xorm.Session, user *User, token string) (err error) {
 	}
 
 	if tk == nil {
-		// TODO: return invalid token error
-		return
+		return ErrInvalidAccountDeletionToken{Token: token}
 	}
 
 	err = removeTokens(s, user, TokenAccountDeletion)

--- a/pkg/user/error.go
+++ b/pkg/user/error.go
@@ -209,6 +209,29 @@ func IsErrInvalidEmailConfirmToken(err error) bool {
 	return ok
 }
 
+// ErrInvalidAccountDeletionToken is an error where the account deletion token is invalid
+type ErrInvalidAccountDeletionToken struct {
+	Token string
+}
+
+func (err ErrInvalidAccountDeletionToken) Error() string {
+	return fmt.Sprintf("Invalid account deletion token [Token: %s]", err.Token)
+}
+
+// ErrCodeInvalidAccountDeletionToken holds the unique world-error code of this error
+const ErrCodeInvalidAccountDeletionToken = 1027
+
+// HTTPError holds the http error description
+func (err ErrInvalidAccountDeletionToken) HTTPError() web.HTTPError {
+	return web.HTTPError{HTTPCode: http.StatusPreconditionFailed, Code: ErrCodeInvalidAccountDeletionToken, Message: "Invalid account deletion token."}
+}
+
+// IsErrInvalidAccountDeletionToken checks if an error is a ErrInvalidAccountDeletionToken.
+func IsErrInvalidAccountDeletionToken(err error) bool {
+	_, ok := err.(ErrInvalidAccountDeletionToken)
+	return ok
+}
+
 // ErrWrongUsernameOrPassword is an error where the email was not confirmed
 type ErrWrongUsernameOrPassword struct {
 }

--- a/pkg/webtests/user_confirm_deletion_test.go
+++ b/pkg/webtests/user_confirm_deletion_test.go
@@ -1,0 +1,35 @@
+// Vikunja is a to-do list application to facilitate your life.
+// Copyright 2018-present Vikunja and contributors. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package webtests
+
+import (
+	"net/http"
+	"testing"
+
+	apiv1 "code.vikunja.io/api/pkg/routes/api/v1"
+	"code.vikunja.io/api/pkg/user"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserConfirmDeletion(t *testing.T) {
+	t.Run("Invalid token", func(t *testing.T) {
+		_, err := newTestRequestWithUser(t, http.MethodPost, apiv1.UserConfirmDeletion, &testuser1, `{"token": "invalid"}`, nil, nil)
+		require.Error(t, err)
+		assertHandlerErrorCode(t, err, user.ErrCodeInvalidAccountDeletionToken)
+	})
+}


### PR DESCRIPTION
## Summary
- return a clear error when confirming deletion with an invalid token
- add english translation for deletion token error
- test invalid token on account deletion confirmation

## Testing
- `mage lint:fix`
- `pnpm lint:fix`


------
https://chatgpt.com/codex/tasks/task_e_68669407702483209fc972ef877f5a94