### PR TITLE
fix(user): persist status on email update

### DIFF
--- a/pkg/user/update_email.go
+++ b/pkg/user/update_email.go
@@ -55,22 +55,24 @@ func UpdateEmail(s *xorm.Session, update *EmailUpdate) (err error) {
 
 	// Send the confirmation mail
 	if !config.MailerEnabled.GetBool() {
+		update.User.Status = StatusActive
 		_, err = s.
 			Where("id = ?", update.User.ID).
-			Cols("email").
+			Cols("email", "status").
 			Update(update.User)
 		return
 	}
 
 	update.User.Status = StatusEmailConfirmationRequired
-	token, err := generateToken(s, update.User, TokenEmailConfirm)
+	_, err = s.
+		Where("id = ?", update.User.ID).
+		Cols("email", "status").
+		Update(update.User)
 	if err != nil {
 		return
 	}
-	_, err = s.
-		Where("id = ?", update.User.ID).
-		Cols("email", "is_active"). // TODO: Status change
-		Update(update.User)
+
+	token, err := generateToken(s, update.User, TokenEmailConfirm)
 	if err != nil {
 		return
 	}

--- a/pkg/user/update_email_test.go
+++ b/pkg/user/update_email_test.go
@@ -1,0 +1,62 @@
+// Vikunja is a to-do list application to facilitate your life.
+// Copyright 2018-present Vikunja and contributors. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+package user
+
+import (
+	"testing"
+
+	"code.vikunja.io/api/pkg/config"
+	"code.vikunja.io/api/pkg/db"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateEmailStatusPersistence(t *testing.T) {
+	t.Run("mailer enabled", func(t *testing.T) {
+		db.LoadAndAssertFixtures(t)
+		s := db.NewSession()
+		defer s.Close()
+
+		config.MailerEnabled.Set(true)
+		defer config.MailerEnabled.Set(false)
+
+		err := UpdateEmail(s, &EmailUpdate{User: &User{ID: 1}, NewEmail: "new1@example.com"})
+		require.NoError(t, err)
+
+		updated, err := GetUserByID(s, 1)
+		require.NoError(t, err)
+		assert.Equal(t, StatusEmailConfirmationRequired, updated.Status)
+		assert.Equal(t, "new1@example.com", updated.Email)
+	})
+
+	t.Run("mailer disabled", func(t *testing.T) {
+		db.LoadAndAssertFixtures(t)
+		s := db.NewSession()
+		defer s.Close()
+
+		config.MailerEnabled.Set(false)
+
+		err := UpdateEmail(s, &EmailUpdate{User: &User{ID: 2}, NewEmail: "new2@example.com"})
+		require.NoError(t, err)
+
+		updated, err := GetUserByID(s, 2)
+		require.NoError(t, err)
+		assert.Equal(t, StatusActive, updated.Status)
+		assert.Equal(t, "new2@example.com", updated.Email)
+	})
+}

--- a/pkg/user/user.go
+++ b/pkg/user/user.go
@@ -581,7 +581,7 @@ func UpdateUser(s *xorm.Session, user *User, forceOverride bool) (updatedUser *U
 			"email",
 			"avatar_provider",
 			"avatar_file_id",
-			"is_active",
+			"status",
 			"name",
 			"email_reminders_enabled",
 			"discoverable_by_name",

--- a/pkg/user/user_create.go
+++ b/pkg/user/user_create.go
@@ -108,7 +108,7 @@ func CreateUser(s *xorm.Session, user *User) (newUser *User, err error) {
 
 	_, err = s.
 		Where("id = ?", user.ID).
-		Cols("email", "is_active").
+		Cols("email", "status").
 		Update(user)
 	if err != nil {
 		return

--- a/pkg/user/user_email_confirm.go
+++ b/pkg/user/user_email_confirm.go
@@ -54,7 +54,7 @@ func ConfirmEmail(s *xorm.Session, c *EmailConfirm) (err error) {
 	}
 	_, err = s.
 		Where("id = ?", user.ID).
-		Cols("is_active").
+		Cols("status").
 		Update(user)
 	return
 }


### PR DESCRIPTION
## Summary
- update email updates to persist `status` column before token generation
- switch other flows from `is_active` to `status`
- handle status when mailer is disabled
- add unit test for status persistence
- use Conventional Commit style

## Testing
- `mage lint:fix`
- `mage test:feature` *(fails: signal interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686693d622248320ade413f6c695f6dd