### PR TITLE
Move db time format constant to utils

### DIFF
--- a/pkg/models/task_overdue_reminder.go
+++ b/pkg/models/task_overdue_reminder.go
@@ -37,7 +37,7 @@ func getUndoneOverdueTasks(s *xorm.Session, now time.Time) (usersWithTasks map[i
 
 	var tasks []*Task
 	err = s.
-		Where("due_date is not null AND due_date < ? AND projects.is_archived = false", nextMinute.Add(time.Hour*14).Format(dbTimeFormat)).
+		Where("due_date is not null AND due_date < ? AND projects.is_archived = false", nextMinute.Add(time.Hour*14).Format(utils.DbTimeFormat)).
 		Join("LEFT", "projects", "projects.id = tasks.project_id").
 		And("done = false").
 		Find(&tasks)

--- a/pkg/models/task_reminder.go
+++ b/pkg/models/task_reminder.go
@@ -68,8 +68,6 @@ type taskUser struct {
 	User *user.User `xorm:"extends"`
 }
 
-const dbTimeFormat = `2006-01-02 15:04:05`
-
 func getTaskUsersForTasks(s *xorm.Session, taskIDs []int64, cond builder.Cond) (taskUsers []*taskUser, err error) {
 	if len(taskIDs) == 0 {
 		return
@@ -172,7 +170,7 @@ func getTasksWithRemindersDueAndTheirUsers(s *xorm.Session, now time.Time) (remi
 	err = s.
 		Join("INNER", "tasks", "tasks.id = task_reminders.task_id").
 		// All reminders from -12h to +14h to include all time zones
-		Where("reminder >= ? and reminder < ?", now.Add(time.Hour*-12).Format(dbTimeFormat), nextMinute.Add(time.Hour*14).Format(dbTimeFormat)).
+		Where("reminder >= ? and reminder < ?", now.Add(time.Hour*-12).Format(utils.DbTimeFormat), nextMinute.Add(time.Hour*14).Format(utils.DbTimeFormat)).
 		And("tasks.done = false").
 		Find(&reminders)
 	if err != nil {

--- a/pkg/utils/time.go
+++ b/pkg/utils/time.go
@@ -22,6 +22,10 @@ import (
 	"code.vikunja.io/api/pkg/config"
 )
 
+// DbTimeFormat describes the default datetime layout used for database queries.
+// It matches the standard MySQL DATETIME format without timezone information.
+const DbTimeFormat = "2006-01-02 15:04:05"
+
 // GetTimeWithoutNanoSeconds returns a time.Time without the nanoseconds.
 func GetTimeWithoutNanoSeconds(t time.Time) time.Time {
 	tz := config.GetTimeZone()


### PR DESCRIPTION
## Summary
- centralize db time format constant in `pkg/utils`
- use new constant in reminder cron jobs
- run `go vet`

## Testing
- `go vet ./...`

------
https://chatgpt.com/codex/tasks/task_e_686e27a9cfd883208fc3b9d13d677d3c